### PR TITLE
minor README change for OSX

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -12,7 +12,11 @@ git-flow installer, which can be run using the following command:
 
 	$ wget -q -O - http://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sudo sh
 
-For Windows users who wish to use the automated install, it is suggested that you install [Cygwin](http://www.cygwin.com/)
+For __OSX__ users, the `wget` command isn't available by default, but `curl` is, so you can run:
+
+	$ curl http://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sudo sh
+
+For __Windows__ users who wish to use the automated install, it is suggested that you install [Cygwin](http://www.cygwin.com/)
 first to install tools like sh and wget. Then simply follow the command:
 
 	c:\Users\<user> wget -q -O - http://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sh


### PR DESCRIPTION
`wget` doesn't seem to be available by default on OSX, but `curl` is, so I added a line to the README.
