### PR TITLE
Allow for dynamic naming of versiontags

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -39,7 +39,7 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(git config --get gitflow.prefix.versiontag)
+VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
 PREFIX=$(git config --get gitflow.prefix.hotfix)
 
 usage() {

--- a/git-flow-release
+++ b/git-flow-release
@@ -39,7 +39,7 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(git config --get gitflow.prefix.versiontag)
+VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
 PREFIX=$(git config --get gitflow.prefix.release)
 
 usage() {

--- a/git-flow-support
+++ b/git-flow-support
@@ -39,7 +39,7 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(git config --get gitflow.prefix.versiontag)
+VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
 PREFIX=$(git config --get gitflow.prefix.support)
 
 warn "note: The support subcommand is still very EXPERIMENTAL!"


### PR DESCRIPTION
Hey Vincent,

Our typical workflow at work dictates that our tags be prefixed by a date, to allow for things such as auto-deployment and other purposes, so I thought it might be helpful to allow the inclusion of bash replacement on versiontag prefixes. For example we would set our versiontag prefix to be::

```
git config --global gitflow.prefix.versiontag "production/\$(date +%Y/%m/%d/)"
```

which would result in::

```
production/2010/09/22/my-hotfix-or-feature-name
```

What do you think about adding support for this type of customization? I am not a bash expert, so there is probably a much better way of enabling this sort of thing, but this is just my first stab (it does actually work)

FYI: I did not enable this for any other prefixing, do to the fact that you do replacement work to allow the listing of existing branches, but no such work is done on versiontags.

Thanks!
Nowell Strite
