### PR TITLE
release "backmerge" flag; backwards-compatible and git describe friendly

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -377,8 +377,8 @@ cmd_publish() {
 	git fetch -q "$ORIGIN"
 
 	# configure remote tracking
-	git config "branch.$BRANCH.remote" "$ORIGIN"
-	git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
+	gitflow_config_set "branch.$BRANCH.remote" "$ORIGIN"
+	gitflow_config_set "branch.$BRANCH.merge" "refs/heads/$BRANCH"
 	git checkout "$BRANCH"
 
 	echo

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -377,8 +377,8 @@ cmd_publish() {
 	git fetch -q "$ORIGIN"
 
 	# configure remote tracking
-	gitflow_config_set "branch.$BRANCH.remote" "$ORIGIN"
-	gitflow_config_set "branch.$BRANCH.merge" "refs/heads/$BRANCH"
+	git config "branch.$BRANCH.remote" "$ORIGIN"
+	git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
 	git checkout "$BRANCH"
 
 	echo

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -39,7 +39,7 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-PREFIX=$(git config --get gitflow.prefix.feature)
+PREFIX=$(gitflow_config_get gitflow.prefix.feature)
 
 usage() {
 	echo "usage: git flow feature [list] [-v]"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.hotfix)
+VERSION_PREFIX=$(eval "echo `gitflow_config_get gitflow.prefix.versiontag`")
+PREFIX=$(gitflow_config_get gitflow.prefix.hotfix)
 
 usage() {
 	echo "usage: git flow hotfix [list] [-v]"

--- a/git-flow-init
+++ b/git-flow-init
@@ -76,7 +76,7 @@ cmd_default() {
 	# add a master branch if no such branch exists yet
 	local master_branch
 	if gitflow_has_master_configured && ! flag force; then
-		master_branch=$(git config --get gitflow.branch.master)
+		master_branch=$(gitflow_config_get gitflow.branch.master)
 	else
 		# Two cases are distinguished:
 		# 1. A fresh git repo (without any branches)
@@ -90,7 +90,7 @@ cmd_default() {
 		if [ "$branch_count" -eq 0 ]; then
 			echo "No branches exist yet. Base branches must be created now."
 			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.master || echo master)
+			default_suggestion=$(gitflow_config_get gitflow.branch.master || echo master)
 		else
 			echo
 			echo "Which branch should be used for bringing forth production releases?"
@@ -98,7 +98,7 @@ cmd_default() {
 
 			should_check_existence=YES
 			default_suggestion=
-			for guess in $(git config --get gitflow.branch.master) \
+			for guess in $(gitflow_config_get gitflow.branch.master) \
 			             'production' 'main' 'master'; do
 				if git_local_branch_exists "$guess"; then
 					default_suggestion="$guess"
@@ -128,7 +128,7 @@ cmd_default() {
 	# add a develop branch if no such branch exists yet
 	local develop_branch
 	if gitflow_has_develop_configured && ! flag force; then
-		develop_branch=$(git config --get gitflow.branch.develop)
+		develop_branch=$(gitflow_config_get gitflow.branch.develop)
 	else
 		# Again, the same two cases as with the master selection are
 		# considered (fresh repo or repo that contains branches)
@@ -137,7 +137,7 @@ cmd_default() {
 		branch_count=$(git_local_branches | grep -v "^${master_branch}\$" | wc -l)
 		if [ "$branch_count" -eq 0 ]; then
 			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
+			default_suggestion=$(gitflow_config_get gitflow.branch.develop || echo develop)
 		else
 			echo
 			echo "Which branch should be used for integration of the \"next release\"?"
@@ -145,7 +145,7 @@ cmd_default() {
 
 			should_check_existence=YES
 			default_suggestion=
-			for guess in $(git config --get gitflow.branch.develop) \
+			for guess in $(gitflow_config_get gitflow.branch.develop) \
 			             'develop' 'int' 'integration' 'master'; do
 				if git_local_branch_exists "$guess"; then
 					default_suggestion="$guess"
@@ -214,11 +214,11 @@ cmd_default() {
 
 	# finally, ask the user for naming conventions (branch and tag prefixes)
 	if flag force || \
-	   ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.support >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1; then
+	   ! gitflow_config_get gitflow.prefix.feature >/dev/null 2>&1 || 
+	   ! gitflow_config_get gitflow.prefix.release >/dev/null 2>&1 || 
+	   ! gitflow_config_get gitflow.prefix.hotfix >/dev/null 2>&1 || 
+	   ! gitflow_config_get gitflow.prefix.support >/dev/null 2>&1 || 
+	   ! gitflow_config_get gitflow.prefix.versiontag >/dev/null 2>&1; then
 		echo
 		echo "How to name your supporting branch prefixes?"
 	fi
@@ -226,8 +226,8 @@ cmd_default() {
 	local prefix
 
 	# Feature branches
-	if ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature/)
+	if ! gitflow_config_get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(gitflow_config_get gitflow.prefix.feature || echo feature/)
 		printf "Feature branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -239,8 +239,8 @@ cmd_default() {
 	fi
 
 	# Release branches
-	if ! git config --get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.release || echo release/)
+	if ! gitflow_config_get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(gitflow_config_get gitflow.prefix.release || echo release/)
 		printf "Release branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -253,8 +253,8 @@ cmd_default() {
 
 
 	# Hotfix branches
-	if ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix/)
+	if ! gitflow_config_get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(gitflow_config_get gitflow.prefix.hotfix || echo hotfix/)
 		printf "Hotfix branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -267,8 +267,8 @@ cmd_default() {
 
 
 	# Support branches
-	if ! git config --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.support || echo support/)
+	if ! gitflow_config_get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(gitflow_config_get gitflow.prefix.support || echo support/)
 		printf "Support branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -281,8 +281,8 @@ cmd_default() {
 
 
 	# Version tag prefix
-	if ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "")
+	if ! gitflow_config_get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(gitflow_config_get gitflow.prefix.versiontag || echo "")
 		printf "Version tag prefix? [$default_suggestion] "
 		if noflag defaults; then
 			read answer

--- a/git-flow-init
+++ b/git-flow-init
@@ -122,7 +122,7 @@ cmd_default() {
 		fi
 
 		# store the name of the master branch
-		git config gitflow.branch.master "$master_branch"
+		gitflow_config_set gitflow.branch.master "$master_branch"
 	fi
 
 	# add a develop branch if no such branch exists yet
@@ -173,7 +173,7 @@ cmd_default() {
 		fi
 
 		# store the name of the develop branch
-		git config gitflow.branch.develop "$develop_branch"
+		gitflow_config_set gitflow.branch.develop "$develop_branch"
 	fi
 
 	# Creation of HEAD
@@ -235,7 +235,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.feature "$prefix"
+		gitflow_config_set gitflow.prefix.feature "$prefix"
 	fi
 
 	# Release branches
@@ -248,7 +248,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.release "$prefix"
+		gitflow_config_set gitflow.prefix.release "$prefix"
 	fi
 
 
@@ -262,7 +262,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.hotfix "$prefix"
+		gitflow_config_set gitflow.prefix.hotfix "$prefix"
 	fi
 
 
@@ -276,7 +276,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.support "$prefix"
+		gitflow_config_set gitflow.prefix.support "$prefix"
 	fi
 
 
@@ -290,7 +290,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.versiontag "$prefix"
+		gitflow_config_set gitflow.prefix.versiontag "$prefix"
 	fi
 
 

--- a/git-flow-init
+++ b/git-flow-init
@@ -37,7 +37,7 @@
 #
 
 usage() {
-	echo "usage: git flow init [-fd]"
+	echo "usage: git flow init [-fdp]"
 }
 
 parse_args() {
@@ -46,10 +46,23 @@ parse_args() {
 	eval set -- "${FLAGS_ARGV}"
 }
 
+# save config values to .gitflow if publish flag was specified
+gitflow_config_set() {
+	if flag publish; then
+	    local key=$1
+	    local value=$2
+	    local config=$(gitflow_config_path)
+	    git config --file "$config" $key "$value"
+	else
+	    git config "$config" $key "$value"
+	fi
+}
+
 # Default entry when no SUBACTION is given
 cmd_default() {
 	DEFINE_boolean force false 'force setting of gitflow branches, even if already configured' f
 	DEFINE_boolean defaults false 'use default branch naming conventions' d
+	DEFINE_boolean publish false 'publish settings to .gitflow' p
 	parse_args "$@"
 	
 	if ! git rev-parse --git-dir >/dev/null 2>&1; then

--- a/git-flow-release
+++ b/git-flow-release
@@ -45,7 +45,7 @@ PREFIX=$(git config --get gitflow.prefix.release)
 usage() {
 	echo "usage: git flow release [list] [-v]"
 	echo "       git flow release start [-F] <version> [<base>]"
-	echo "       git flow release finish [-Fsumpk] <version>"
+	echo "       git flow release finish [-Fsumpkb] <version>"
 	echo "       git flow release publish <name>"
 	echo "       git flow release track <name>"
 }
@@ -193,7 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
-	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
+	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)" b
 
 	parse_args "$@"
 	require_version_arg

--- a/git-flow-release
+++ b/git-flow-release
@@ -193,7 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
-	DEFINE_boolean backmerge false "back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
+	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
 
 	parse_args "$@"
 	require_version_arg
@@ -246,7 +246,7 @@ cmd_finish() {
 	fi
 
 	# try to merge into develop
-	if flag backmerge; then
+	if noflag nobackmerge; then
 		# in case a previous attempt to finish this release branch has failed,
 		# but the merge into develop was successful, we skip it now
 		if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
@@ -302,18 +302,16 @@ cmd_finish() {
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
-	if noflag backmerge; then
-		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
-	fi
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
-		if flag backmerge; then
+		if noflag nobackmerge; then
 			echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
 		fi
+	fi
+	if flag nobackmerge; then
+		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
 	else
-		if flag backmerge; then
-			echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
-		fi
+        echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
 	fi
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"

--- a/git-flow-release
+++ b/git-flow-release
@@ -314,8 +314,8 @@ cmd_publish() {
 	git fetch -q "$ORIGIN"
 
 	# configure remote tracking
-	gitflow_config_set "branch.$BRANCH.remote" "$ORIGIN"
-	gitflow_config_set "branch.$BRANCH.merge" "refs/heads/$BRANCH"
+	git config "branch.$BRANCH.remote" "$ORIGIN"
+	git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
 	git checkout "$BRANCH"
 
 	echo

--- a/git-flow-release
+++ b/git-flow-release
@@ -193,6 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+	DEFINE_boolean backmerge false "back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
 
 	parse_args "$@"
 	require_version_arg
@@ -245,21 +246,34 @@ cmd_finish() {
 	fi
 
 	# try to merge into develop
-	# in case a previous attempt to finish this release branch has failed,
-	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
-		git checkout "$DEVELOP_BRANCH" || \
-		  die "Could not check out $DEVELOP_BRANCH."
+	if flag backmerge; then
+		# in case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
 
-		# merge the master branch back into develop; this makes the master
-		# branch - and the new tag (if provided) - a parent of the development
-		# branch, which in turn lets you use 'git describe' on either branch
-		if noflag notag; then
-		  git merge --no-ff "$tagname" || \
-		    die "There were merge conflicts."
-		else
-		  git merge --no-ff "$MASTER_BRANCH" || \
-		    die "There were merge conflicts."
+			# merge the master branch back into develop; this makes the master
+			# branch - and the new tag (if provided) - a parent of the development
+			# branch, which in turn lets you use 'git describe' on either branch
+			if noflag notag; then
+			  git merge --no-ff "$tagname" || \
+			    die "There were merge conflicts."
+			else
+			  git merge --no-ff "$MASTER_BRANCH" || \
+			    die "There were merge conflicts."
+			fi
+		fi
+	else
+		# in case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
+
+			# just merge the release branch into the development branch
+			git merge --no-ff "$BRANCH" || \
+			  die "There were merge conflicts."
 		fi
 	fi
 
@@ -288,11 +302,18 @@ cmd_finish() {
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
+	if noflag backmerge; then
+		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
+	fi
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
-		echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+		if flag backmerge; then
+			echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+		fi
 	else
-		echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		if flag backmerge; then
+			echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		fi
 	fi
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"

--- a/git-flow-release
+++ b/git-flow-release
@@ -247,15 +247,20 @@ cmd_finish() {
 	# try to merge into develop
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
+	if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
 		git checkout "$DEVELOP_BRANCH" || \
 		  die "Could not check out $DEVELOP_BRANCH."
 
-		# TODO: Actually, accounting for 'git describe' pays, so we should
-		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+		# merge the master branch back into develop; this makes the master
+		# branch - and the new tag (if provided) - a parent of the development
+		# branch, which in turn lets you use 'git describe' on either branch
+		if noflag notag; then
+		  git merge --no-ff "$tagname" || \
+		    die "There were merge conflicts."
+		else
+		  git merge --no-ff "$MASTER_BRANCH" || \
+		    die "There were merge conflicts."
+		fi
 	fi
 
 	# delete branch
@@ -285,8 +290,10 @@ cmd_finish() {
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
+		echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+	else
+		echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
 	fi
-	echo "- Release branch has been back-merged into '$DEVELOP_BRANCH'"
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"
 	else

--- a/git-flow-release
+++ b/git-flow-release
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.release)
+VERSION_PREFIX=$(eval "echo `gitflow_config_get gitflow.prefix.versiontag`")
+PREFIX=$(gitflow_config_get gitflow.prefix.release)
 
 usage() {
 	echo "usage: git flow release [list] [-v]"

--- a/git-flow-release
+++ b/git-flow-release
@@ -314,8 +314,8 @@ cmd_publish() {
 	git fetch -q "$ORIGIN"
 
 	# configure remote tracking
-	git config "branch.$BRANCH.remote" "$ORIGIN"
-	git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"
+	gitflow_config_set "branch.$BRANCH.remote" "$ORIGIN"
+	gitflow_config_set "branch.$BRANCH.merge" "refs/heads/$BRANCH"
 	git checkout "$BRANCH"
 
 	echo

--- a/git-flow-support
+++ b/git-flow-support
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.support)
+VERSION_PREFIX=$(eval "echo `gitflow_config_get gitflow.prefix.versiontag`")
+PREFIX=$(gitflow_config_get gitflow.prefix.support)
 
 warn "note: The support subcommand is still very EXPERIMENTAL!"
 warn "note: DO NOT use it in a production situation."

--- a/gitflow-common
+++ b/gitflow-common
@@ -171,14 +171,6 @@ gitflow_config_get() {
 	return $success
 }
 
-# save config values to .gitflow
-gitflow_config_set() {
-	local key=$1
-	local value=$2
-	local config=$(gitflow_config_path)
-	git config --file "$config" $key "$value"
-}
-
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
 	local master=$(gitflow_config_get gitflow.branch.master)

--- a/gitflow-common
+++ b/gitflow-common
@@ -152,6 +152,25 @@ git_is_branch_merged_into() {
 # gitflow specific common functionality
 #
 
+# get path for gitflow config file
+gitflow_config_path() {
+	local repo_topdir=$(git rev-parse --show-toplevel)
+	local gitflow_config=".gitflow"
+	echo "$repo_topdir/$gitflow_config"
+}
+
+# get config values from .gitflow or git config
+gitflow_config_get() {
+	local key=$1
+	local config=$(gitflow_config_path)
+	local value
+	value="$(git config --file "$config" --get $key || \
+	    git config --get $key)"
+	local success=$?
+	[ $success -eq 0 ] && echo $value
+	return $success
+}
+
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
 	local master=$(git config --get gitflow.branch.master)

--- a/gitflow-common
+++ b/gitflow-common
@@ -173,37 +173,37 @@ gitflow_config_get() {
 
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
-	local master=$(git config --get gitflow.branch.master)
+	local master=$(gitflow_config_get gitflow.branch.master)
 	[ "$master" != "" ] && git_local_branch_exists "$master"
 }
 
 gitflow_has_develop_configured() {
-	local develop=$(git config --get gitflow.branch.develop)
+	local develop=$(gitflow_config_get gitflow.branch.develop)
 	[ "$develop" != "" ] && git_local_branch_exists "$develop"
 }
 
 gitflow_has_prefixes_configured() {
-	git config --get gitflow.prefix.feature >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.release >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
-	git config --get gitflow.prefix.support >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.versiontag >/dev/null 2>&1
+	gitflow_config_get gitflow.prefix.feature >/dev/null 2>&1     && \
+	gitflow_config_get gitflow.prefix.release >/dev/null 2>&1     && \
+	gitflow_config_get gitflow.prefix.hotfix >/dev/null 2>&1      && \
+	gitflow_config_get gitflow.prefix.support >/dev/null 2>&1     && \
+	gitflow_config_get gitflow.prefix.versiontag >/dev/null 2>&1
 }
 
 gitflow_is_initialized() {
 	gitflow_has_master_configured                    && \
 	gitflow_has_develop_configured                   && \
-	[ "$(git config --get gitflow.branch.master)" !=    \
-	  "$(git config --get gitflow.branch.develop)" ] && \
+	[ "$(gitflow_config_get gitflow.branch.master)" !=    \
+	  "$(gitflow_config_get gitflow.branch.develop)" ] && \
 	gitflow_has_prefixes_configured
 }
 
 # loading settings that can be overridden using git config
 gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
-	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
-	export ORIGIN=$(git config --get gitflow.origin || echo origin)
+	export MASTER_BRANCH=$(gitflow_config_get gitflow.branch.master)
+	export DEVELOP_BRANCH=$(gitflow_config_get gitflow.branch.develop)
+	export ORIGIN=$(gitflow_config_get gitflow.origin || echo origin)
 }
 
 #

--- a/gitflow-common
+++ b/gitflow-common
@@ -171,6 +171,14 @@ gitflow_config_get() {
 	return $success
 }
 
+# save config values to .gitflow
+gitflow_config_set() {
+	local key=$1
+	local value=$2
+	local config=$(gitflow_config_path)
+	git config --file "$config" $key "$value"
+}
+
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
 	local master=$(gitflow_config_get gitflow.branch.master)


### PR DESCRIPTION
Vincent,

This is a patch I threw together for use within my organization. The idea is to provide the facility for merging a release tag back into the development branch, for git describe -- I know from your inline comments as well as some list discussions, etc. that you are aware of this and plan to support it in the python rewrite.

This feature was added as an option during release finish, and is false by default to avoid affecting the way anything works by default.

I would love to see support for this in the pre-python git-flow. If these changes make sense to you, great. If not, I can always maintain my own fork until the python version is ready :)

Groetjes,
- Ben
