### PR TITLE
Installer for msysgit environment

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -37,6 +37,10 @@ installer, which can be run using the following command:
 	$ wget --no-check-certificate -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sudo sh
 
 ### Windows
+
+For Windows users, [msysgit](http://code.google.com/p/msysgit/) is a good
+starting place for installing git.
+
 #### Using Cygwin
 For Windows users who wish to use the automated install, it is suggested that you install [Cygwin](http://www.cygwin.com/)
 first to install tools like `git`, `util-linux` and `wget` (with those three being packages that can be selected
@@ -44,32 +48,19 @@ during installation). Then simply run this command from a Cygwin shell:
 
 	$ wget -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sh
 
-#### Using msysgit
-This is much like the manual installation below, but there are additional steps required to install some extra tools that
-are not distributed with [msysgit](http://code.google.com/p/msysgit/).
+#### Using [msysgit](http://code.google.com/p/msysgit/)
+Download and install `getopt.exe` from the [util-linux package](http://gnuwin32.sourceforge.net/packages/util-linux-ng.htm) into `C:\Program Files\Git\bin`. (Only `getopt.exe`, the others util-linux files are not used).
 
-Clone the git-flow sources from Github:
+Clone the git-flow sources from GitHub:
 
 	$ git clone --recursive git://github.com/nvie/gitflow.git
+	$ cd gitflow
 
-Copy git-flow's relevant files to your msysgit installation directory:
+Run the `msysgit-install` script from a command-line prompt (you may have to
+run it with "Full Administrator" rights if you installed msysgit with its
+installer):
 
-	$ mkdir /usr/local/bin
-	$ cp git-flow* gitflow* /usr/local/bin/
-	$ cp shFlags/src/shflags /usr/local/bin/gitflow-shFlags
-
-Next up we need to borrow a couple of binaries from [Cygwin](http://www.cygwin.com/). If you don't have Cygwin installed, please 
-install it including the `util-linux` package. Apart from `util-linux`'s dependencies, no other packages are required. When you
-finished installation, copy the following files using msysgit's _Git Bash_. We assume the Cygwin's default installation path in C:\cygwin.
-
-	$ cd /c/cygwin/
-	$ cp bin/getopt.exe /usr/local/bin/
-	$ cp bin/cyggcc_s-1.dll /usr/local/bin/
-	$ cp bin/cygiconv-2.dll /usr/local/bin/
-	$ cp bin/cygintl-8.dll /usr/local/bin/
-	$ cp bin/cygwin1.dll /usr/local/bin/
-
-After copying the files above, you can safely uninstall your Cygwin installation by deleting the C:\cygwin directory.
+	C:\gitflow> contrib\msysgit-install.cmd
 
 ### Manual installation
 If you prefer a manual installation, please use the following instructions:
@@ -103,9 +94,6 @@ For those who use the [Bash](http://www.gnu.org/software/bash/) or
 [git-flow-completion](http://github.com/bobthecow/git-flow-completion) project
 by [bobthecow](http://github.com/bobthecow). It offers tab-completion for all
 git-flow subcommands and branch names.
-
-For Windows users, [msysgit](http://code.google.com/p/msysgit/) is a good
-starting place for installing git.
 
 
 FAQ

--- a/contrib/msysgit-install.cmd
+++ b/contrib/msysgit-install.cmd
@@ -1,0 +1,76 @@
+@echo off
+setlocal
+if not "%~1"=="" set GIT_HOME=%~f1
+if "%GIT_HOME%"=="" call :FindGitHome "git.cmd"
+
+if exist "%GIT_HOME%" goto :GitHomeOK
+
+echo MsysGit installation directory not found.>&2
+echo Try to give the directory name on the command line:>&2
+echo   %0 "%ProgramFiles%\Git"
+endlocal
+exit /B 1
+
+:GitHomeOK
+set ERR=0
+
+echo Installing gitflow into "%GIT_HOME%"...
+
+call :ChkGetopt getopt.exe || set ERR=1
+if %ERR%==1 goto :End
+echo getopt.exe... Found
+
+if not exist "%GIT_HOME%\bin\git-flow" goto :Install
+echo GitFlow is already installed.>&2
+choice /C YN /M "Do you want to replace it"
+if errorlevel 255 goto :Abort
+if errorlevel 2 goto :Abort
+if not errorlevel 1 goto :Abort
+
+echo Deleting old files...
+for /F %%i in ("%GIT_HOME%\git-flow*" "%GIT_HOME%\gitflow-*") do if exist "%%~fi" del /F /Q "%%~fi"
+
+:Install
+echo Copying files...
+::goto :EOF
+xcopy "%~dp0\..\git-flow"            "%GIT_HOME%\bin"                 /Y /R /F
+if errorlevel 4 if not errorlevel 5 goto :AccessDenied
+if errorlevel 1 set ERR=1
+xcopy "%~dp0\..\git-flow*"           "%GIT_HOME%\bin"                 /Y /R /F || set ERR=1
+xcopy "%~dp0\..\gitflow-*"           "%GIT_HOME%\bin"                 /Y /R /F || set ERR=1
+xcopy "%~dp0\..\shFlags\src\shflags" "%GIT_HOME%\bin\gitflow-shFlags" /Y /R /F || set ERR=1
+
+if %ERR%==1 choice /T 30 /C Y /D Y /M "Some unexpected errors happened. Sorry, you'll have to fix them by yourself."
+
+:End
+endlocal & exit /B %ERR%
+goto :EOF
+
+:AccessDenied
+set ERR=1
+echo.
+echo You should run this script with "Full Administrator" rights:>&2
+echo - Right-click with Shift on the script from the Explorer>&2
+echo - Select "Run as administrator">&2
+choice /T 30 /C YN /D Y /N >nul
+goto :End
+
+:Abort
+echo Installation canceled.>&2
+set ERR=1
+goto :End
+
+:ChkGetopt
+:: %1 is getopt.exe
+if exist "%GIT_HOME%\bin\%1" goto :EOF
+if exist "%~f$PATH:1" goto :EOF
+echo %GIT_HOME%\bin\%1 not found.>&2
+echo You have to install this file manually. See the GitFlow README.
+exit /B 1
+
+:FindGitHome
+setlocal
+set GIT_CMD_DIR=%~dp$PATH:1
+if "%GIT_CMD_DIR%"=="" endlocal & goto :EOF
+endlocal & set GIT_HOME=%GIT_CMD_DIR:~0,-5%
+goto :EOF


### PR DESCRIPTION
This patch :
- provides an installer for the msysgit environment
- updates README to use `getopt.exe` from the GnuWin32 binaries of linux-util (issue #73)
- updates README to use the installer
