### PR TITLE
Fixed require_tag_absent to not break when the list of tags contains an a

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -288,9 +288,11 @@ require_branch_absent() {
 }
 
 require_tag_absent() {
-	if has $1 $(git_all_tags); then
-		die "Tag '$1' already exists. Pick another name."
-	fi
+	for tag in $(git_all_tags); do
+		if [ "$1" = "$tag" ]; then
+			die "Tag '$1' already exists. Pick another name."
+		fi
+	done
 }
 
 require_branches_equal() {


### PR DESCRIPTION
Fixed require_tag_absent to not break when the list of tags contains an ambiguous entry, e.g. looking for "1.0.1" in "0.1.0 0.1.1 0.1.2 1.0".
