### PR TITLE
Block hotfix tag on the origin

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -153,20 +153,28 @@ require_no_existing_hotfix_branches() {
 }
 
 cmd_start() {
-	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
+	DEFINE_boolean fetch false "fetch from $ORIGIN before performing start" F
+	DEFINE_boolean tagbase true "tag the base right after starting, implies -F" t
 	parse_args "$@"
 	BASE=${2:-$MASTER_BRANCH}
 	require_version_arg
 	require_base_is_on_master
 	require_no_existing_hotfix_branches
 
+	# set implied flags
+	if flag tagbase; then
+		FLAGS_fetch=$FLAGS_TRUE
+	fi
+
 	# sanity checks
 	require_clean_working_tree
 	require_branch_absent "$BRANCH"
-	require_tag_absent "$VERSION_PREFIX$VERSION"
 	if flag fetch; then
-		git fetch -q "$ORIGIN" "$MASTER_BRANCH"
+		local opts="-q"
+		flag tagbase && opts="$opts --tags"
+		git fetch $opts "$ORIGIN" "$MASTER_BRANCH"
 	fi
+	require_tag_absent "$VERSION_PREFIX$VERSION"
 	if has "$ORIGIN/$MASTER_BRANCH" "$(git_remote_branches)"; then
 		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
 	fi
@@ -174,8 +182,18 @@ cmd_start() {
 	# create branch
 	git checkout -b "$BRANCH" "$BASE"
 
+	# Push the tag to the base of this hotfix.
+	# This ensures "nobody" can start a hotfix with the same tag.
+	if flag tagbase; then
+		git tag "$VERSION_PREFIX$VERSION" "$BASE"
+		git push --tags "$ORIGIN"
+	fi
+
 	echo
 	echo "Summary of actions:"
+	if flag tagbase; then
+		echo "- The new tag has been reserved on the origin."
+	fi
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
 	echo "- You are now on branch '$BRANCH'"
 	echo
@@ -196,12 +214,17 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+	DEFINE_boolean basetagged true "the base has been tagged on start" b
 	parse_args "$@"
 	require_version_arg
 
 	# handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then
 		FLAGS_sign=$FLAGS_TRUE
+	fi
+	if flag basetagged; then
+		FLAGS_notag=$FLAGS_FALSE
+		FLAGS_push=$FLAGS_TRUE
 	fi
 
 	# sanity checks
@@ -236,13 +259,14 @@ cmd_finish() {
 		# in case a previous attempt to finish this release branch has failed,
 		# but the tag was set successful, we skip it now
 		local tagname=$VERSION_PREFIX$VERSION
-		if ! git_tag_exists "$tagname"; then
+		if flag basetagged || ! git_tag_exists "$tagname"; then
 			local opts="-a"
+			flag basetagged && opts="$opts -f"
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			git tag $opts "$VERSION_PREFIX$VERSION" || \
-			die "Tagging failed. Please run finish again to retry."
+				die "Tagging failed. Please run finish again to retry."
 		fi
 	fi
 


### PR DESCRIPTION
While utilizing the hotfix mechanism to deliver patch versions, we encountered the problem, that someone could use the same version number already being used by someone else. We are using version numbers according to http://semver.org/ So after deploying a new release 0.2.0 the next hotfix would be 0.2.1 followed by 0.2.2 etc.

However, if somebody starts the hotfix for 0.2.1 and is not finished at the time someone else finds another issue, he would also start 0.2.1. This patch "blocks" the version tag pointing it to the current base. The second attempt will not be able to use 0.2.1 as the tag already exists.
