### PR TITLE
Document that git flow release start takes an optional base as well 

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -44,7 +44,7 @@ PREFIX=$(git config --get gitflow.prefix.release)
 
 usage() {
 	echo "usage: git flow release [list] [-v]"
-	echo "       git flow release start [-F] <version>"
+	echo "       git flow release start [-F] <version> [<base>]"
 	echo "       git flow release finish [-Fsumpk] <version>"
 	echo "       git flow release publish <name>"
 	echo "       git flow release track <name>"


### PR DESCRIPTION
This info was missing from the 'help' output
