### PR TITLE
Set GITFLOW_DIR correctly if git-flow is a symbolic link

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -42,7 +42,7 @@ if [ "$DEBUG" = "yes" ]; then
 	set -x
 fi
 
-export GITFLOW_DIR=$(dirname "$0")
+export GITFLOW_DIR=$(dirname $(readlink "$0"))
 
 usage() {
 	echo "usage: git flow <subcommand>"


### PR DESCRIPTION
This allows a user to create a symbolic link to git-flow in their
personal bin directory (e.g. ~/bin) without having to add the source
tree to their $PATH or do a system install.
