### PR TITLE
Add version number auto-increment support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ debian/files
 debian/*.substvars
 debian/*.debhelper.log
 debian/*/*
+*.swp

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -242,7 +242,11 @@ cmd_finish() {
 			local opts="-a"
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
-			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+			if [ "$FLAGS_message" != "" ]; then
+        opts="$opts -m '$FLAGS_message'"
+      else
+        opts="$opts -m '$VERSION_PREFIX$VERSION'"
+      fi
 			git tag $opts "$VERSION_PREFIX$VERSION" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -130,9 +130,11 @@ parse_args() {
 
 require_version_arg() {
 	if [ "$VERSION" = "" ]; then
-		warn "Missing argument <version>"
-		usage
-		exit 1
+    default_suggestion="$(git_next_revision_version)"
+		printf "Version number for this hotfix: [$default_suggestion] "
+		read answer
+		VERSION=${answer:-$default_suggestion}
+    BRANCH=$PREFIX$VERSION
 	fi
 }
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -138,6 +138,17 @@ require_version_arg() {
 	fi
 }
 
+require_version_arg_for_finish() {
+	if [ "$VERSION" = "" ]; then
+    default_suggestion="$(gitflow_current_version_from_branch_name)"
+		printf "Version number for this release: [$default_suggestion] "
+		read answer
+		VERSION=${answer:-$default_suggestion}
+    BRANCH=$PREFIX$VERSION
+    require_branch $BRANCH
+	fi
+}
+
 require_base_is_on_master() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
 			| sed 's/[* ] //g' \
@@ -199,7 +210,7 @@ cmd_finish() {
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
 	parse_args "$@"
-	require_version_arg
+	require_version_arg_for_finish
 
 	# handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then

--- a/git-flow-release
+++ b/git-flow-release
@@ -240,7 +240,11 @@ cmd_finish() {
 			local opts="-a"
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
-			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+			if [ "$FLAGS_message" != "" ]; then
+        opts="$opts -m '$FLAGS_message'"
+      else
+        opts="$opts -m '$VERSION_PREFIX$VERSION'"
+      fi
 			git tag $opts "$tagname" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -135,6 +135,17 @@ require_version_arg() {
 	fi
 }
 
+require_version_arg_for_finish() {
+	if [ "$VERSION" = "" ]; then
+    default_suggestion="$(gitflow_current_version_from_branch_name)"
+		printf "Version number for this release: [$default_suggestion] "
+		read answer
+		VERSION=${answer:-$default_suggestion}
+    BRANCH=$PREFIX$VERSION
+    require_branch $BRANCH
+	fi
+}
+
 require_base_is_on_develop() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
 			| sed 's/[* ] //g' \
@@ -197,7 +208,7 @@ cmd_finish() {
 	DEFINE_boolean notag false "don't tag this release" n
 
 	parse_args "$@"
-	require_version_arg
+	require_version_arg_for_finish
 
 	# handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then

--- a/git-flow-release
+++ b/git-flow-release
@@ -127,9 +127,11 @@ parse_args() {
 
 require_version_arg() {
 	if [ "$VERSION" = "" ]; then
-		warn "Missing argument <version>"
-		usage
-		exit 1
+    default_suggestion="$(git_next_minor_version)"
+		printf "Version number for this release: [$default_suggestion] "
+		read answer
+		VERSION=${answer:-$default_suggestion}
+    BRANCH=$PREFIX$VERSION
 	fi
 }
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -105,6 +105,7 @@ git_tag_exists() {
 	has $1 $(git_all_tags)
 }
 
+
 #
 # git_compare_branches()
 #
@@ -311,4 +312,57 @@ require_branches_equal() {
 			die "Branches need merging first."
 		fi
 	fi
+}
+
+#
+# Functions for auto version incrementing
+#
+
+git_current_version() {
+  echo "$(git_all_tags)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)/\1/p'
+}
+
+git_current_major_version() {
+  echo "$(git_current_version)" | sed -n 's/\([0-9]*\).[0-9]*.[0-9]*/\1/p'
+}
+
+git_current_minor_version() {
+  echo "$(git_current_version)" | sed -n 's/[0-9]*.\([0-9]*\).[0-9]*/\1/p'
+}
+
+git_current_revision_version() {
+  echo "$(git_current_version)" | sed -n 's/[0-9]*.[0-9]*.\([0-9]*\)/\1/p'
+}
+
+git_next_major_version() {
+  if [ $(git_current_version) == ""]; then
+    echo "1.0.0"
+  else
+    maj=$( echo "$(git_current_major_version)" | awk '{ print $1 + 1 }' )
+    min=0
+    rev=0
+    echo "$maj.$min.$rev"
+  fi
+}
+
+git_next_minor_version() {
+  if [ $(git_current_version) == ""]; then
+    echo "1.0.0"
+  else
+    maj=$(git_current_major_version)
+    min=$( echo "$(git_current_minor_version)" | awk '{ print $1 + 1 }' )
+    rev=0
+    echo "$maj.$min.$rev"
+  fi
+}
+
+git_next_revision_version() {
+  if [ $(git_current_version) == "" ]; then
+    echo "1.0.0"
+  else
+    maj=$(git_current_major_version)
+    min=$(git_current_minor_version)
+    rev=$( echo "$(git_current_revision_version)" | awk '{ print $1 + 1 }' )
+    echo "$maj.$min.$rev"
+  fi
 }

--- a/gitflow-common
+++ b/gitflow-common
@@ -75,7 +75,7 @@ git_remote_branches() { git branch -r --no-color | sed 's/^[* ] //'; }
 git_all_branches() { ( git branch --no-color; git branch -r --no-color) | sed 's/^[* ] //'; }
 git_all_tags() { git tag; }
 
-git_all_tags_by_date() { git for-each-ref --sort='*authordate' --format='%(tag)' refs/tags; }
+git_all_tags_by_date() { git for-each-ref --sort='*authordate' --format='%(refname:short)' refs/tags; }
 
 git_current_branch() {
 	git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'
@@ -321,7 +321,7 @@ require_branches_equal() {
 #
 
 git_current_version() {
-  echo "$(git_all_tags_by_date)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)/\1/p'
+  echo "$(git_all_tags_by_date)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)[^0-9]*/\1/p'
 }
 
 git_current_major_version() {
@@ -337,7 +337,7 @@ git_current_revision_version() {
 }
 
 git_next_major_version() {
-  if [ $(git_current_version) == ""]; then
+  if [ -z $(git_current_version) ]; then
     echo "1.0.0"
   else
     maj=$( echo "$(git_current_major_version)" | awk '{ print $1 + 1 }' )
@@ -348,7 +348,7 @@ git_next_major_version() {
 }
 
 git_next_minor_version() {
-  if [ $(git_current_version) == ""]; then
+  if [ -z $(git_current_version) ]; then
     echo "1.0.0"
   else
     maj=$(git_current_major_version)
@@ -359,7 +359,7 @@ git_next_minor_version() {
 }
 
 git_next_revision_version() {
-  if [ $(git_current_version) == "" ]; then
+  if [ -z $(git_current_version) ]; then
     echo "1.0.0"
   else
     maj=$(git_current_major_version)

--- a/gitflow-common
+++ b/gitflow-common
@@ -320,6 +320,10 @@ require_branches_equal() {
 # Functions for auto version incrementing
 #
 
+gitflow_current_version_from_branch_name() {
+  echo "$(git_current_branch)" | sed 's/.*\/\(.*\)/\1/g'
+}
+
 git_current_version() {
   echo "$(git_all_tags_by_date)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)[^0-9]*/\1/p'
 }

--- a/gitflow-common
+++ b/gitflow-common
@@ -75,6 +75,8 @@ git_remote_branches() { git branch -r --no-color | sed 's/^[* ] //'; }
 git_all_branches() { ( git branch --no-color; git branch -r --no-color) | sed 's/^[* ] //'; }
 git_all_tags() { git tag; }
 
+git_all_tags_by_date() { git for-each-ref --sort='*authordate' --format='%(tag)' refs/tags; }
+
 git_current_branch() {
 	git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'
 }
@@ -319,7 +321,7 @@ require_branches_equal() {
 #
 
 git_current_version() {
-  echo "$(git_all_tags)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)/\1/p'
+  echo "$(git_all_tags_by_date)" | grep -e '.*[0-9]*\.[0-9]*\.[0-9].*' | sed '$!d' | sed -n 's/[^0-9]*\([0-9]*.[0-9]*.[0-9]\)/\1/p'
 }
 
 git_current_major_version() {


### PR DESCRIPTION
'git flow hotfix start' and 'git flow release start' will suggest
a new version number based on previous tags in the respository.
The respective stop commands will suggest the same version number.
Version numbers are in the form [major].[minor].[revision]
(eg. 1.3.5). Any tag matching this form, regardless of text before
or after, will be recognized as a version number and used for
suggesting. 'hotfix' assumes a revision bump and 'release' assumes
a minor bump, but suggestion can be overridden. In addition
'git flow hotfix start 1.0.0' and 'git flow release start 1.0.0'
still work as expected.
