### PR TITLE
Added support to Makefile to use PREFIX env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@
 ifdef DEB_BUILD_ARCH
    prefix=$(DESTDIR)/usr/
 else
-   prefix=/usr/local
+   ifdef PREFIX
+      prefix=$(PREFIX)
+   else
+      prefix=/usr/local
+   endif
 endif
 
 # files that need mode 755


### PR DESCRIPTION
Hi,

I know you can specify prefix through make:

```
$ make prefix=~ install
```

I've added support to use the `PREFIX` env var if it exists, since that is it often used in different projects.
