### PR TITLE
Fix parsing for Bourne shell (FreeBSD)

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -94,7 +94,7 @@ main() {
 	# in that case, we interpret this arg as a flag for the default
 	# command
 	SUBACTION="default"
-	if [ "$1" != "" ] && ! echo "$1" | grep -q "^-"; then
+	if [ "$1" != "" ] && { ! echo "$1" | grep -q "^-"; } then
 		SUBACTION="$1"; shift
 	fi
 	if ! type "cmd_$SUBACTION" >/dev/null 2>&1; then


### PR DESCRIPTION
Will fix nvie/gitflow#125 ... Tested on FreeBSD 6.1 but it should work with any bourne shell
