### PR TITLE
Ref: issue #23 - Tryng to automate tracking of origin/develop

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -295,6 +295,15 @@ cmd_default() {
 
 
 	# TODO: what to do with origin?
+
+        # We are on develop, so let's automagically track origin/develop && make
+        # sure it is updated
+        if git_branch_exists "origin/$develop_branch"; then
+                git branch --set-upstream "$develop_branch" "origin/$develop_branch"
+                warn "Now pulling updates from origin/$develop_branch to $develop_branch ..."
+                git pull
+        fi
+
 }
 
 cmd_help() {

--- a/git-flow-init
+++ b/git-flow-init
@@ -302,6 +302,11 @@ cmd_default() {
                 git branch --set-upstream "$develop_branch" "origin/$develop_branch"
                 warn "Now pulling updates from origin/$develop_branch to $develop_branch ..."
                 git pull
+	else
+		warn "It seems to me you are using git-flow-init for the first time on this git repository."
+		warn "Thus, you may likely find rather useful to run"
+		warn "\n\t\tgit branch --set-upstream ${develop_branch} origin/${develop_branch}\n"
+		warn "after your first push of branch: ${develop_branch}"
         fi
 
 }

--- a/git-flow-init
+++ b/git-flow-init
@@ -307,6 +307,7 @@ cmd_default() {
 		warn "Thus, you may likely find rather useful to run"
 		warn "\n\t\tgit branch --set-upstream ${develop_branch} origin/${develop_branch}\n"
 		warn "after your first push of branch: ${develop_branch}"
+		warn "\t\t( git push origin ${develop_branch} )"
         fi
 
 }


### PR DESCRIPTION
Ref: nvie/gitflow#23

Being a beginner with both git and git-flow, today I just found out why after a `git flow init` my `develop` branch always seemed to be old compared to `origin/develop`: it was based on `master`, and never being updated to `origin/develop`.

Looking for answers, I found the aforementioned nvie/gitflow#23 and wrote down a quick hack that works for me.

Hoping it could prove somewhat useful to anyone else, and dangerous to nobody, I dare submit this pull request.

Regards,
William Ghelfi
