### PR TITLE
Adding windows install step for libintl3.dll

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -49,7 +49,7 @@ during installation). Then simply run this command from a Cygwin shell:
 	$ wget -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
 
 #### Using [msysgit](http://code.google.com/p/msysgit/)
-Download and install `getopt.exe` from the [util-linux package](http://gnuwin32.sourceforge.net/packages/util-linux-ng.htm) into `C:\Program Files\Git\bin`. (Only `getopt.exe`, the others util-linux files are not used).
+Download and install `getopt.exe` from the [util-linux package](http://gnuwin32.sourceforge.net/packages/util-linux-ng.htm) into `C:\Program Files\Git\bin`. (Only `getopt.exe`, the others util-linux files are not used). Also install `libintl3.dll` from the Dependencies package, into the same directory. 
 
 Clone the git-flow sources from GitHub:
 


### PR DESCRIPTION
I found I also needed to install this file. It was mentioned in issue #109. Adding this step to the instruction might help others avoid this same problem.
