### PR TITLE
feature/merge-msg

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -311,7 +311,13 @@ cmd_finish() {
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		git merge --ff "$BRANCH"
 	else
-		git merge --no-ff "$BRANCH"
+		local msg=$(gitflow_render_merge_message "$BRANCH" "$DEVELOP_BRANCH")
+
+		if [ "$msg" != "" ]; then
+			git merge --no-ff -m "$msg" "$BRANCH"
+		else
+			git merge --no-ff "$BRANCH"
+		fi
 	fi
 
 	if [ $? -ne 0 ]; then

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -226,9 +226,19 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+
+		local msg=$(gitflow_render_merge_message "$BRANCH" "$MASTER_BRANCH")
+
+		if [ "$msg" != "" ]; then
+			git merge --no-ff -m "$msg" "$BRANCH"
+		else
+			git merge --no-ff "$BRANCH"
+		fi
+
+		if [ $? -ne 0 ]; then
+			die "There were merge conflicts."
+			# TODO: What do we do now?
+		fi
 	fi
 
 	if noflag notag; then
@@ -253,11 +263,21 @@ cmd_finish() {
 		git checkout "$DEVELOP_BRANCH" || \
 		  die "Could not check out $DEVELOP_BRANCH."
 
+		local msg=$(gitflow_render_merge_message "$BRANCH" "$DEVELOP_BRANCH")
+
 		# TODO: Actually, accounting for 'git describe' pays, so we should
 		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+
+		if [ "$msg" != "" ]; then
+			git merge --no-ff -m "$msg" "$BRANCH"
+		else
+			git merge --no-ff "$BRANCH"
+		fi
+
+		if [ $? -ne 0 ]; then
+			die "There were merge conflicts."
+			# TODO: What do we do now?
+		fi
 	fi
 
 	# delete branch

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -251,7 +251,7 @@ cmd_finish() {
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
-			git tag $opts "$VERSION_PREFIX$VERSION" || \
+			git tag $opts "$tagname" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -224,9 +224,19 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+
+		local msg=$(gitflow_render_merge_message "$BRANCH" "$MASTER_BRANCH")
+
+		if [ "$msg" != "" ]; then
+			git merge --no-ff -m "$msg" "$BRANCH"
+		else
+			git merge --no-ff "$BRANCH"
+		fi
+
+		if [ $? -ne 0 ]; then
+			die "There were merge conflicts."
+			# TODO: What do we do now?
+		fi
 	fi
 
 	if noflag notag; then
@@ -251,11 +261,21 @@ cmd_finish() {
 		git checkout "$DEVELOP_BRANCH" || \
 		  die "Could not check out $DEVELOP_BRANCH."
 
+		local msg=$(gitflow_render_merge_message "$BRANCH" "$DEVELOP_BRANCH")
+
 		# TODO: Actually, accounting for 'git describe' pays, so we should
 		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+
+		if [ "$msg" != "" ]; then
+			git merge --no-ff -m "$msg" "$BRANCH"
+		else
+			git merge --no-ff "$BRANCH"
+		fi
+
+		if [ $? -ne 0 ]; then
+			die "There were merge conflicts."
+			# TODO: What do we do now?
+		fi
 	fi
 
 	# delete branch

--- a/gitflow-common
+++ b/gitflow-common
@@ -188,6 +188,25 @@ gitflow_load_settings() {
 }
 
 #
+# gitflow_render_merge_message
+#
+# Inputs:
+# $1 = source branch
+# $2 = destination branch
+#
+# Renders a pre-defined merge message.
+gitflow_render_merge_message() {
+	local src_branch=$1
+	local dst_branch=$2
+
+	local msg=$(eval "echo $(git config --get gitflow.merge.message)")
+
+	if [ "$msg" != "" ]; then
+		echo "$msg"
+	fi
+}
+
+#
 # gitflow_resolve_nameprefix
 #
 # Inputs:


### PR DESCRIPTION
Hey!

I've added a simple way to pre-define a merge message template to be used while merging with the feature/hotfix/release commands.

You can use it by including the following in your .git/config:

```
[gitflow "merge"]
    message = Merge branch \\'$src_branch\\' into \\'$dst_branch\\'.
```

I've also fixed the usage of a local variable which was already defined but never used.

Cheers,
Erik
