### PR TITLE
When merging into master the release branch is always preferred, so let t

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -224,7 +224,7 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
+		git merge --no-ff -srecursive -Xtheirs "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi


### PR DESCRIPTION
When merging into master the release branch is always preferred, so let the merge know and prevent conflicts.
Using the recursive/theirs strategy the release is always preferred.
