### PR TITLE
Adding the `eval` to force variable expansion.

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -241,7 +241,7 @@ cmd_finish() {
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
-			git tag $opts "$VERSION_PREFIX$VERSION" || \
+			eval git tag $opts "$VERSION_PREFIX$VERSION" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -239,7 +239,7 @@ cmd_finish() {
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
-			git tag $opts "$tagname" || \
+			eval git tag $opts "$tagname" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi


### PR DESCRIPTION
This has been bugging me for a long time and finally had some time to try and figure out what is going on with the `-m` not working.

I found that the same 'command' that the git flow is executing worked fine in stand alone bash but was failing when run within the script.

Found that it isn't expanding the variables correctly:

http://fvue.nl/wiki/Bash:_Why_use_eval_with_variable_expansion

This may be something that we want to add to all the git commands that are passing a string based option.

Closes #50
