### PR TITLE
Added check for Windows environment so that we can fix paths

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -42,8 +42,8 @@ if [ "$DEBUG" = "yes" ]; then
 	set -x
 fi
 
-if [ "$(echo $OS | grep -ic windows)" == 1 ]; then
-	export GITFLOW_DIR=$(dirname "$(echo $0 | sed -e 's,\\,/,g')")
+if [[ $OS == Windows* ]]; then
+	export GITFLOW_DIR=$(dirname "${0//\\/\/}")
 else
 	export GITFLOW_DIR=$(dirname "$0")
 fi

--- a/git-flow
+++ b/git-flow
@@ -43,8 +43,7 @@ if [ "$DEBUG" = "yes" ]; then
 fi
 
 if [ -n "$MSYSTEM" ]; then
-	export GITFLOW_DIR=$(dirname "$(echo $0 | \
-		sed -e 's,\(.\):,/\1,g' -e 's,;,:,g' -e 's,\\,/,g')")
+	export GITFLOW_DIR=$(dirname "$(echo $0 | sed -e 's,\\,/,g')")
 else
 	export GITFLOW_DIR=$(dirname "$0")
 fi

--- a/git-flow
+++ b/git-flow
@@ -42,7 +42,7 @@ if [ "$DEBUG" = "yes" ]; then
 	set -x
 fi
 
-if [ -n "$MSYSTEM" ]; then
+if [ "$(echo $OS | grep -ic windows)" == 1 ]; then
 	export GITFLOW_DIR=$(dirname "$(echo $0 | sed -e 's,\\,/,g')")
 else
 	export GITFLOW_DIR=$(dirname "$0")

--- a/git-flow
+++ b/git-flow
@@ -42,7 +42,13 @@ if [ "$DEBUG" = "yes" ]; then
 	set -x
 fi
 
-export GITFLOW_DIR=$(dirname "$0")
+if [ -n "$MSYSTEM" ]; then
+	export GITFLOW_DIR=$(dirname "$(echo $0 | \
+		sed -e 's,\(.\):,/\1,g' -e 's,;,:,g' -e 's,\\,/,g')")
+else
+	export GITFLOW_DIR=$(dirname "$0")
+fi
+
 
 usage() {
 	echo "usage: git flow <subcommand>"


### PR DESCRIPTION
After a recent installation of msysGit (Git-1.7.7-preview20111014.exe), I've found that the path seems to be getting mangled when invoking git-flow, and the following error occurs:

``` sh
$ git flow init
C:\Program Files (x86)\Git\bin\git-flow: line 68: ./gitflow-common: No such file or directory
C:\Program Files (x86)\Git\bin\git-flow: line 76: ./gitflow-shFlags: No such file or directory
```

This turns out to be because the `GITFLOW_DIR` variable is created by using `dirname $0` and `$0` in this case happens to be a Windows path with backslashes, and so the command just returns '.' instead of the actual path to Git.

This patch checks to see if we're in a Windows environment and if so converts the path accordingly.
