### PR TITLE
git flow clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ EXEC_FILES=git-flow
 
 # files that need mode 644
 SCRIPT_FILES =git-flow-init
+SCRIPT_FILES+=git-flow-clone
 SCRIPT_FILES+=git-flow-feature
 SCRIPT_FILES+=git-flow-hotfix
 SCRIPT_FILES+=git-flow-release

--- a/README.mdown
+++ b/README.mdown
@@ -137,6 +137,10 @@ you would like to use as development and production branches, and how you
 would like your prefixes be named. You may simply press Return on any of
 those questions to accept the (sane) default suggestions.
 
+Alternatively, you can clone an existing repo that utilizes git flow:
+
+		git flow clone <repository>
+
 
 ### Creating feature/release/hotfix/support branches
 

--- a/git-flow
+++ b/git-flow
@@ -49,7 +49,7 @@ usage() {
 	echo
 	echo "Available subcommands are:"
 	echo "   init      Initialize a new git repo with support for the branching model."
-	echo "   clone     Clone an existing git repo that uses git flow"
+	echo "   clone     Clone an existing git repo that uses git flow."
 	echo "   feature   Manage your feature branches."
 	echo "   release   Manage your release branches."
 	echo "   hotfix    Manage your hotfix branches."

--- a/git-flow
+++ b/git-flow
@@ -49,7 +49,7 @@ usage() {
 	echo
 	echo "Available subcommands are:"
 	echo "   init      Initialize a new git repo with support for the branching model."
-    echo "   clone     Clone an existing git repo that uses git flow"
+	echo "   clone     Clone an existing git repo that uses git flow"
 	echo "   feature   Manage your feature branches."
 	echo "   release   Manage your release branches."
 	echo "   hotfix    Manage your hotfix branches."

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -97,8 +97,3 @@ cmd_clone() {
 	echo "- The local branch $DEVELOP_BRANCH was configured to track the remote branch"
 	echo
 }
-
-cmd_help() {
-	usage
-	exit 0
-}

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -66,10 +66,16 @@ cmd_clone() {
 
     mkdir "$DIRECTORY" || die "git flow clone aborted. Could not create directory $DIRECTORY"
     cd "$DIRECTORY"
-    git init
+    git init > /dev/null 2>&1
     require_git_repo
     git remote add origin "$REPO"
     git fetch
+
+    if [ "$?" -ne "0" ]; then
+        cd ..
+        rm -r "$DIRECTORY"
+        exit 1
+    fi
 
     git flow init
     require_gitflow_initialized

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -88,7 +88,7 @@ cmd_clone() {
 	git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"
 
 	git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
-	git checkout -b "$DEVELOP_BRANCH" "origin/$MASTER_BRANCH"
+	git checkout -b "$DEVELOP_BRANCH" "origin/$DEVELOP_BRANCH"
 
 	echo
 	echo "Summary of actions:"

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -46,15 +46,42 @@ parse_args() {
 	# parse options
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
+
+    REPO=$1
+    DIRECTORY=`echo "$REPO" | sed "s/.*[/:]//g" | sed "s/\.git//g"`
 }
 
 # Default entry when no SUBACTION is given
 cmd_default() {
-    cmd_clone
+    cmd_clone "$@"
 }
 
 cmd_clone() {
-    echo "Cloning"
+    parse_args "$@"
+
+    mkdir "$DIRECTORY" || die "git flow clone aborted. Could not create directory $DIRECTORY"
+    cd "$DIRECTORY"
+    git init
+    require_git_repo
+    git flow init
+    require_gitflow_initialized
+    gitflow_load_settings
+
+    git remote add origin "$REPO"
+    git fetch
+
+    git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
+    git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"
+
+    git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
+    git checkout -b "$DEVELOP_BRANCH" "origin/$MASTER_BRANCH"
+
+	echo
+	echo "Summary of actions:"
+	echo "- Repository $REPO was cloned"
+	echo "- $MASTER_BRANCH branch was set to track $MASTER_BRANCH at $REPO"
+	echo "- $DEVELOP_BRANCH branch was set to track $DEVELOP_BRANCH at $REPO"
+	echo
 }
 
 cmd_help() {

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -59,16 +59,22 @@ cmd_default() {
 cmd_clone() {
     parse_args "$@"
 
+    if [ "$REPO" == "" ]; then
+        usage
+        exit 1
+    fi
+
     mkdir "$DIRECTORY" || die "git flow clone aborted. Could not create directory $DIRECTORY"
     cd "$DIRECTORY"
     git init
     require_git_repo
+    git remote add origin "$REPO"
+    git fetch
+
     git flow init
     require_gitflow_initialized
     gitflow_load_settings
 
-    git remote add origin "$REPO"
-    git fetch
 
     git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
     git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -79,8 +79,8 @@ cmd_clone() {
 	echo
 	echo "Summary of actions:"
 	echo "- Repository $REPO was cloned"
-	echo "- $MASTER_BRANCH branch was set to track $MASTER_BRANCH at $REPO"
-	echo "- $DEVELOP_BRANCH branch was set to track $DEVELOP_BRANCH at $REPO"
+	echo "- The local branch $MASTER_BRANCH was configured to track the remote branch"
+	echo "- The local branch $DEVELOP_BRANCH was configured to track the remote branch"
 	echo
 }
 

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -47,46 +47,48 @@ parse_args() {
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
 
-    REPO=$1
-    DIRECTORY=`echo "$REPO" | sed "s/.*[/:]//g" | sed "s/\.git//g"`
+	REPO=$1
+	DIRECTORY=`echo "$REPO" | sed "s/.*[/:]//g" | sed "s/\.git//g"`
 }
 
 # Default entry when no SUBACTION is given
 cmd_default() {
-    cmd_clone "$@"
+	cmd_clone "$@"
 }
 
 cmd_clone() {
-    parse_args "$@"
+	parse_args "$@"
 
-    if [ "$REPO" == "" ]; then
-        usage
-        exit 1
-    fi
+	if [ "$REPO" == "" ]; then
+		usage
+		exit 1
+	fi
 
-    mkdir "$DIRECTORY" || die "git flow clone aborted. Could not create directory $DIRECTORY"
-    cd "$DIRECTORY"
-    git init > /dev/null 2>&1
-    require_git_repo
-    git remote add origin "$REPO"
-    git fetch
+	mkdir "$DIRECTORY" || die "git flow clone aborted. Could not create directory $DIRECTORY"
+	cd "$DIRECTORY"
 
-    if [ "$?" -ne "0" ]; then
-        cd ..
-        rm -r "$DIRECTORY"
-        exit 1
-    fi
+	git init > /dev/null 2>&1
+	require_git_repo
 
-    git flow init
-    require_gitflow_initialized
-    gitflow_load_settings
+	git remote add origin "$REPO"
+	git fetch
+
+	if [ "$?" -ne "0" ]; then
+		cd ..
+		rm -r "$DIRECTORY"
+		exit 1
+	fi
+
+	git flow init
+	require_gitflow_initialized
+	gitflow_load_settings
 
 
-    git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
-    git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"
+	git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
+	git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"
 
-    git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
-    git checkout -b "$DEVELOP_BRANCH" "origin/$MASTER_BRANCH"
+	git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
+	git checkout -b "$DEVELOP_BRANCH" "origin/$MASTER_BRANCH"
 
 	echo
 	echo "Summary of actions:"

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -39,7 +39,7 @@
 NO_SUBACTION=true
 
 usage() {
-	echo "usage: git flow clone <repository>"
+	echo "usage: git flow clone <repository> [-d]"
 }
 
 parse_args() {
@@ -56,8 +56,11 @@ cmd_default() {
 	cmd_clone "$@"
 }
 
+# Clone an existing repository that already uses git flow
 cmd_clone() {
+	DEFINE_boolean defaults false 'use default branch naming conventions' d
 	parse_args "$@"
+	ORIGIN="origin"
 
 	if [ "$REPO" == "" ]; then
 		usage
@@ -70,30 +73,65 @@ cmd_clone() {
 	git init > /dev/null 2>&1
 	require_git_repo
 
-	git remote add origin "$REPO"
+	git remote add "$ORIGIN" "$REPO"
 	git fetch
 
+	# Fetch failed, so it's probably not a git repository
 	if [ "$?" -ne "0" ]; then
 		cd ..
 		rm -r "$DIRECTORY"
 		exit 1
 	fi
 
-	git flow init
+	if flag defaults; then
+		git flow init -d
+	else
+		git flow init
+	fi
+
 	require_gitflow_initialized
 	gitflow_load_settings
 
+	tracking_master=false
+	tracking_develop=false
 
-	git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
-	git checkout -b "$MASTER_BRANCH" "origin/$MASTER_BRANCH"
+	# Track the remote master branch if it exists
+	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
+		git branch -D "$MASTER_BRANCH" > /dev/null 2>&1
+		git checkout -b "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+		tracking_master=true
+	fi
 
-	git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
-	git checkout -b "$DEVELOP_BRANCH" "origin/$DEVELOP_BRANCH"
+	# Track the remote develop branch if it exists
+	if git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH"; then
+		git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
+		git checkout -b "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
+		tracking_develop=true
+	
+	# Create the develop branch if the remote develop branch doesn't exist
+	elif "$tracking_master"; then
+		git branch -D "$DEVELOP_BRANCH" > /dev/null 2>&1
+		git checkout -b "$DEVELOP_BRANCH" "$MASTER_BRANCH"
+	fi
+
+	# Switch to the develop branch
+	git checkout "$DEVELOP_BRANCH"
 
 	echo
 	echo "Summary of actions:"
 	echo "- Repository $REPO was cloned"
-	echo "- The local branch $MASTER_BRANCH was configured to track the remote branch"
-	echo "- The local branch $DEVELOP_BRANCH was configured to track the remote branch"
+	if "$tracking_master"; then
+		echo "- The local branch $MASTER_BRANCH was configured to track the remote branch"
+	else
+		echo "- The local branch $MASTER_BRANCH was created"
+	fi
+	if "$tracking_develop"; then
+		echo "- The local branch $DEVELOP_BRANCH was configured to track the remote branch"
+	elif "$tracking_master"; then
+		echo "- The local branch $DEVELOP_BRANCH was created based on the $MASTER_BRANCH branch"
+	else
+		echo "- The local branch $DEVELOP_BRANCH was created"
+	fi
+	echo "- You are on the $DEVELOP_BRANCH branch"
 	echo
 }

--- a/git-flow-clone
+++ b/git-flow-clone
@@ -1,4 +1,3 @@
-#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -37,75 +36,28 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-# enable debug mode
-if [ "$DEBUG" = "yes" ]; then
-	set -x
-fi
-
-export GITFLOW_DIR=$(dirname "$0")
+NO_SUBACTION=true
 
 usage() {
-	echo "usage: git flow <subcommand>"
-	echo
-	echo "Available subcommands are:"
-	echo "   init      Initialize a new git repo with support for the branching model."
-    echo "   clone     Clone an existing git repo that uses git flow"
-	echo "   feature   Manage your feature branches."
-	echo "   release   Manage your release branches."
-	echo "   hotfix    Manage your hotfix branches."
-	echo "   support   Manage your support branches."
-	echo "   version   Shows version information."
-	echo
-	echo "Try 'git flow <subcommand> help' for details."
+	echo "usage: git flow clone <repository>"
 }
 
-main() {
-	if [ $# -lt 1 ]; then
-		usage
-		exit 1
-	fi
-
-	# load common functionality
-	. "$GITFLOW_DIR/gitflow-common"
-
-	# This environmental variable fixes non-POSIX getopt style argument
-	# parsing, effectively breaking git-flow subcommand parsing on several
-	# Linux platforms.
-	export POSIXLY_CORRECT=1
-
-	# use the shFlags project to parse the command line arguments
-	. "$GITFLOW_DIR/gitflow-shFlags"
-	FLAGS_PARENT="git flow"
+parse_args() {
+	# parse options
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
-
-	# sanity checks
-	SUBCOMMAND="$1"; shift
-
-	if [ ! -e "$GITFLOW_DIR/git-flow-$SUBCOMMAND" ]; then
-		usage
-		exit 1
-	fi
-
-	# run command
-	. "$GITFLOW_DIR/git-flow-$SUBCOMMAND"
-	FLAGS_PARENT="git flow $SUBCOMMAND"
-
-	# test if the first argument is a flag (i.e. starts with '-')
-	# in that case, we interpret this arg as a flag for the default
-	# command
-	SUBACTION="default"
-	if [ "$1" != "" ] && [ ! "$NO_SUBACTION" ] && { ! echo "$1" | grep -q "^-"; } then
-		SUBACTION="$1"; shift
-	fi
-	if ! type "cmd_$SUBACTION" >/dev/null 2>&1; then
-		warn "Unknown subcommand: '$SUBACTION'"
-		usage
-		exit 1
-	fi
-
-	# run the specified action
-	cmd_$SUBACTION "$@"
 }
 
-main "$@"
+# Default entry when no SUBACTION is given
+cmd_default() {
+    cmd_clone
+}
+
+cmd_clone() {
+    echo "Cloning"
+}
+
+cmd_help() {
+	usage
+	exit 0
+}

--- a/gitflow-common
+++ b/gitflow-common
@@ -97,6 +97,10 @@ git_local_branch_exists() {
 	has $1 $(git_local_branches)
 }
 
+git_remote_branch_exists() {
+	has $1 $(git_remote_branches)
+}
+
 git_branch_exists() {
 	has $1 $(git_all_branches)
 }


### PR DESCRIPTION
This pull request may not be feature complete but I wanted to open it up for discussion.

This adds an additional subcommand to git flow for cloning repositories that use the git flow branching model. Instead of having to run multiple commands to clone and setup a repository for git flow, it would be handy to just run a single command that clones, initializes git flow, and sets up tracking for the develop and master branches.

Simply run:

```
git flow clone git@github.com:nvie/gitflow.git
```

And the repository will be cloned, git flow will get initialized, and you will be put on the develop branch.
