### PR TITLE
add a option for remote repository

### DIFF
--- a/Changes.mdown
+++ b/Changes.mdown
@@ -1,3 +1,7 @@
+0.5.0:
+-----
+Adding [--remote|-R] option with hotfix, feature and release subcommands by Motonori Iwata.
+
 0.4.2:
 -----
 Release date: **not yet**

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@
 
 # Determine if we're inside a debian build .. 
 ifdef DEB_BUILD_ARCH
-   prefix=$(DESTDIR)/usr/
+	prefix=$(DESTDIR)/usr/
 else
-   prefix=/usr/local
+	prefix=/usr/local
 endif
 
 # files that need mode 755
@@ -59,5 +59,7 @@ install:
 
 uninstall:
 	test -d $(prefix)/bin && \
-	cd $(prefix)/bin && \
-	rm -f $(EXEC_FILES) $(SCRIPT_FILES)
+		cd $(prefix)/bin && \
+		rm -f $(EXEC_FILES) $(SCRIPT_FILES)
+
+# vim: set noexpandtab ff=unix sts=0 :

--- a/README.mdown
+++ b/README.mdown
@@ -2,7 +2,7 @@ git-flow ![Project status](http://stillmaintained.com/nvie/gitflow.png)
 ========
 A collection of Git extensions to provide high-level repository operations
 for Vincent Driessen's [branching model](http://nvie.com/git-model "original
-blog post").
+		blog post").
 
 
 Getting started
@@ -24,17 +24,18 @@ Installing git-flow
 ### Mac OS
 If you're on a Mac and use [homebrew](http://github.com/mxcl/homebrew), it's simple:
 
-    $ brew install git-flow
+$ brew install https://github.com/iwata/gitflow/raw/master/git-flow.rb
 
-If you're on a Mac and use [MacPorts](http://macports.org/), it's simple:
+#### --zsh-completion option
+For zsh user:
 
-    $ port install git-flow
+$ brew install --zsh-completion https://github.com/iwata/gitflow/raw/master/git-flow.rb
 
 ### Linux, etc.
 Another easy way to install git-flow is using Rick Osborne's excellent git-flow
 installer, which can be run using the following command:
 
-	$ wget --no-check-certificate -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sudo bash
+$ wget --no-check-certificate -q -O - https://github.com/iwata/gitflow/raw/master/contrib/gitflow-installer.sh | sudo bash
 
 ### Windows
 
@@ -44,143 +45,199 @@ starting place for installing git.
 #### Using Cygwin
 For Windows users who wish to use the automated install, it is suggested that you install [Cygwin](http://www.cygwin.com/)
 first to install tools like `git`, `util-linux` and `wget` (with those three being packages that can be selected
-during installation). Then simply run this command from a Cygwin shell:
+		during installation). Then simply run this command from a Cygwin shell:
 
-	$ wget -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | bash
+$ wget -q -O - https://github.com/iwata/gitflow/raw/master/contrib/gitflow-installer.sh | bash
 
 #### Using [msysgit](http://code.google.com/p/msysgit/)
 Download and install `getopt.exe` from the [util-linux package](http://gnuwin32.sourceforge.net/packages/util-linux-ng.htm) into `C:\Program Files\Git\bin`. (Only `getopt.exe`, the others util-linux files are not used). Also install `libintl3.dll` from the Dependencies package, into the same directory. 
 
 Clone the git-flow sources from GitHub:
 
-	$ git clone --recursive git://github.com/nvie/gitflow.git
-	$ cd gitflow
+$ git clone --recursive git://github.com/iwata/gitflow.git
+$ cd gitflow
 
 Run the `msysgit-install` script from a command-line prompt (you may have to
-run it with "Full Administrator" rights if you installed msysgit with its
-installer):
+		run it with "Full Administrator" rights if you installed msysgit with its
+		installer):
 
 	C:\gitflow> contrib\msysgit-install.cmd
 
 ### Manual installation
-If you prefer a manual installation, please use the following instructions:
+	If you prefer a manual installation, please use the following instructions:
 
-	$ git clone --recursive git://github.com/nvie/gitflow.git
+	$ git clone --recursive git://github.com/iwata/gitflow.git
 
-Then, you can install `git-flow`, using:
+	Then, you can install `git-flow`, using:
 
 	$ sudo make install
 
-By default, git-flow will be installed in /usr/local. To change the prefix
-where git-flow will be installed, simply specify it explicitly, using:
+	By default, git-flow will be installed in /usr/local. To change the prefix
+	where git-flow will be installed, simply specify it explicitly, using:
 
 	$ sudo make prefix=/opt/local install
 
-Or simply point your `PATH` environment variable to your git-flow checkout
-directory.
+	Or simply point your `PATH` environment variable to your git-flow checkout
+	directory.
 
-*Installation note:*  
-git-flow depends on the availability of the command line utility `getopt`,
-which may not be available in your Unix/Linux environment.  Please use your
-favorite package manager to install `getopt`.  For Cygwin, install the
-`util-linux` package to get `getopt`.  If you use `apt-get` as your install
-manager, the package name is `opt`.
+	*Installation note:*  
+	git-flow depends on the availability of the command line utility `getopt`,
+	which may not be available in your Unix/Linux environment.  Please use your
+	favorite package manager to install `getopt`.  For Cygwin, install the
+	`util-linux` package to get `getopt`.  If you use `apt-get` as your install
+	manager, the package name is `opt`.
+
+## Postscript
+	Adding [--remote|-R] option with hotfix, feature and release subcommands.
+
+### for the hotfix subcommand
+
+	$ git flow hotfix start -R <hotfix name>
+
+	create local branch and push remote branch to $ORIGIN:
+
+	$ git push --set-upstream $ORIGIN $HOTFIX_BRANCH
+	---------------------------
+	$ git flow hotfix finish -R <hotfix name>
+
+	merge to develop and master branch, remove local hotfix branch, push develop, master and tags branch to $ORIGIN
+	and remove remote hotfix at $ORIGIN:
+
+	$ git push $ORIGIN master
+	$ git push $ORIGIN develop
+	$ git push --tags $ORIGIN
+	$ git push $ORIGIN :$HOTFIX_BRANCH
+
+### for the feature subcommand
+
+	$ git flow feature start -R <feature name>
+
+	create local branch and push remote branch to $ORIGIN:
+
+	$ git push --set-upstream $ORIGIN $FEATURE_BRANCH
+	---------------------------
+	$ git flow hotfix finish -R <hotfix name>
+
+	merge to develop branch, remove local feature branch, push develop branch to $ORIGIN
+	and remove remote feature at $ORIGIN:
+
+	$ git push $ORIGIN develop
+	$ git push $ORIGIN :$FEATURE_BRANCH
+
+### for the release subcommand
+
+	$ git flow release start -R <release> name>
+
+	create local branch and push remote branch to $ORIGIN:
+
+	$ git push --set-upstream $ORIGIN $RELEASE_BRANCH
+	---------------------------
+	$ git flow release finish -R <hotfix name>
+
+	merge to develop and master branch, remove local release branch, push develop, master and tags branch to $ORIGIN
+	and remove remote release at $ORIGIN:
+
+	$ git push $ORIGIN master
+	$ git push $ORIGIN develop
+	$ git push --tags $ORIGIN
+	$ git push $ORIGIN :$RELEASE_BRANCH
+
+	Integration with your shell
+	---------------------------
+	For those who use the [Bash](http://www.gnu.org/software/bash/) or
+	[ZSH](http://www.zsh.org) shell, please check out the excellent work on the
+	[git-flow-completion](http://github.com/bobthecow/git-flow-completion) project
+	by [bobthecow](http://github.com/bobthecow). It offers tab-completion for all
+	git-flow subcommands and branch names.
 
 
-Integration with your shell
----------------------------
-For those who use the [Bash](http://www.gnu.org/software/bash/) or
-[ZSH](http://www.zsh.org) shell, please check out the excellent work on the
-[git-flow-completion](http://github.com/bobthecow/git-flow-completion) project
-by [bobthecow](http://github.com/bobthecow). It offers tab-completion for all
-git-flow subcommands and branch names.
+	FAQ
+	---
+	See the [FAQ](http://github.com/nvie/gitflow/wiki/FAQ) section of the project
+	Wiki.
 
 
-FAQ
----
-See the [FAQ](http://github.com/nvie/gitflow/wiki/FAQ) section of the project
-Wiki.
+	Please help out
+	---------------
+	This project is still under development. Feedback and suggestions are very
+	welcome and I encourage you to use the [Issues
+	list](http://github.com/nvie/gitflow/issues) on Github to provide that
+	feedback.
+
+	Feel free to fork this repo and to commit your additions. For a list of all
+	contributors, please see the [AUTHORS](AUTHORS) file.
+
+	Any questions, tips, or general discussion can be posted to our Google group:
+	[http://groups.google.com/group/gitflow-users](http://groups.google.com/group/gitflow-users)
 
 
-Please help out
----------------
-This project is still under development. Feedback and suggestions are very
-welcome and I encourage you to use the [Issues
-list](http://github.com/nvie/gitflow/issues) on Github to provide that
-feedback.
-
-Feel free to fork this repo and to commit your additions. For a list of all
-contributors, please see the [AUTHORS](AUTHORS) file.
-
-Any questions, tips, or general discussion can be posted to our Google group:
-[http://groups.google.com/group/gitflow-users](http://groups.google.com/group/gitflow-users)
-
-
-License terms
--------------
-git-flow is published under the liberal terms of the BSD License, see the
-[LICENSE](LICENSE) file. Although the BSD License does not require you to share
-any modifications you make to the source code, you are very much encouraged and
-invited to contribute back your modifications to the community, preferably
-in a Github fork, of course.
+	License terms
+	-------------
+	git-flow is published under the liberal terms of the BSD License, see the
+	[LICENSE](LICENSE) file. Although the BSD License does not require you to share
+	any modifications you make to the source code, you are very much encouraged and
+	invited to contribute back your modifications to the community, preferably
+	in a Github fork, of course.
 
 
 ### Initialization
 
-To initialize a new repo with the basic branch structure, use:
-  
-		git flow init
-  
-This will then interactively prompt you with some questions on which branches
-you would like to use as development and production branches, and how you
-would like your prefixes be named. You may simply press Return on any of
-those questions to accept the (sane) default suggestions.
+	To initialize a new repo with the basic branch structure, use:
+
+	git flow init
+
+	This will then interactively prompt you with some questions on which branches
+	you would like to use as development and production branches, and how you
+	would like your prefixes be named. You may simply press Return on any of
+	those questions to accept the (sane) default suggestions.
 
 
 ### Creating feature/release/hotfix/support branches
 
-* To list/start/finish feature branches, use:
-  
-  		git flow feature
-  		git flow feature start <name> [<base>]
-  		git flow feature finish <name>
-  
-  For feature branches, the `<base>` arg must be a commit on `develop`.
+	* To list/start/finish feature branches, use:
 
-* To list/start/finish release branches, use:
-  
-  		git flow release
-  		git flow release start <release> [<base>]
-  		git flow release finish <release>
-  
-  For release branches, the `<base>` arg must be a commit on `develop`.
-  
-* To list/start/finish hotfix branches, use:
-  
-  		git flow hotfix
-  		git flow hotfix start <release> [<base>]
-  		git flow hotfix finish <release>
-  
-  For hotfix branches, the `<base>` arg must be a commit on `master`.
+	git flow feature
+	git flow feature start <name> [<base>]
+	git flow feature finish <name>
 
-* To list/start support branches, use:
-  
-  		git flow support
-  		git flow support start <release> <base>
-  
-  For support branches, the `<base>` arg must be a commit on `master`.
+	For feature branches, the `<base>` arg must be a commit on `develop`.
+
+	* To list/start/finish release branches, use:
+
+	git flow release
+	git flow release start <release> [<base>]
+	git flow release finish <release>
+
+	For release branches, the `<base>` arg must be a commit on `develop`.
+
+	* To list/start/finish hotfix branches, use:
+
+	git flow hotfix
+	git flow hotfix start <release> [<base>]
+	git flow hotfix finish <release>
+
+	For hotfix branches, the `<base>` arg must be a commit on `master`.
+
+	* To list/start support branches, use:
+
+	git flow support
+	git flow support start <release> <base>
+
+	For support branches, the `<base>` arg must be a commit on `master`.
 
 
-Showing your appreciation
-=========================
-A few people already requested it, so now it's here: a Flattr button.
+	Showing your appreciation
+	=========================
+	A few people already requested it, so now it's here: a Flattr button.
 
-Of course, the best way to show your appreciation for the original
-[blog post](http://nvie.com/git-model) or the git-flow tool itself remains
-contributing to the community.  If you'd like to show your appreciation in
-another way, however, consider Flattr'ing me:
+	Of course, the best way to show your appreciation for the original
+	[blog post](http://nvie.com/git-model) or the git-flow tool itself remains
+	contributing to the community.  If you'd like to show your appreciation in
+	another way, however, consider Flattr'ing me:
 
-[![Flattr this][2]][1]
+	[![Flattr this][2]][1]
 
-[1]: http://flattr.com/thing/53771/git-flow
-[2]: http://api.flattr.com/button/button-static-50x60.png
+	[1]: http://flattr.com/thing/53771/git-flow
+	[2]: http://api.flattr.com/button/button-static-50x60.png
+
+# vim: set noexpandtab ff=unix sts=0 :

--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -2,10 +2,10 @@
 
 # git-flow make-less installer for *nix systems, by Rick Osborne
 # Based on the git-flow core Makefile:
-# http://github.com/nvie/gitflow/blob/master/Makefile
+# http://github.com/iwata/gitflow/blob/master/Makefile
 
 # Licensed under the same restrictions as git-flow:
-# http://github.com/nvie/gitflow/blob/develop/LICENSE
+# http://github.com/iwata/gitflow/blob/develop/LICENSE
 
 # Does this need to be smarter for each host OS?
 if [ -z "$INSTALL_PREFIX" ] ; then
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="http://github.com/iwata/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"

--- a/git-flow
+++ b/git-flow
@@ -108,3 +108,5 @@ main() {
 }
 
 main "$@"
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -43,8 +43,12 @@ PREFIX=$(git config --get gitflow.prefix.feature)
 
 usage() {
 	echo "usage: git flow feature [list] [-v]"
-	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFk] [<name|nameprefix>]"
+	echo "       git flow feature start [-F|--fetch] [-P|--pull] <version> [<base>]"
+	echo "       git flow feature start [-R|--remote] <version> [<base>]"
+	echo "       git flow feature finish [-F|--fetch] [-P|--pull]"
+	echo "                               [-r|--rebase] [-k|--keep] [<name|nameprefix>]"
+	echo "       git flow feature finish [-R|--remote]"
+	echo "                               [-r|--rebase] [-k|--keep] [<name|nameprefix>]"
 	echo "       git flow feature publish <name>"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
@@ -137,8 +141,8 @@ expand_nameprefix_arg() {
 	exitcode=$?
 	case $exitcode in
 		0) NAME=$expanded_name
-		   BRANCH=$PREFIX$NAME
-		   ;;
+			BRANCH=$PREFIX$NAME
+			;;
 		*) exit 1 ;;
 	esac
 }
@@ -180,6 +184,17 @@ parse_args() {
 	BRANCH=$PREFIX$NAME
 }
 
+parse_start_args() {
+	# parse options
+	FLAGS "$@" || exit $?
+	eval set -- "${FLAGS_ARGV}"
+
+	# read arguments into global variables
+	NAME=$1
+	BRANCH=$PREFIX$NAME
+	BASE=${2:-$DEVELOP_BRANCH}
+}
+
 parse_remote_name() {
 	# parse options
 	FLAGS "$@" || exit $?
@@ -192,9 +207,10 @@ parse_remote_name() {
 }
 
 cmd_start() {
-	DEFINE_boolean fetch false 'fetch from origin before performing local operation' F
-	parse_args "$@"
-	BASE=${2:-$DEVELOP_BRANCH}
+	DEFINE_boolean fetch false "fetch from $ORIGIN before performing local operation" F
+	DEFINE_boolean pull true "pull from $ORIGIN before performing local operation" P
+	DEFINE_boolean remote false "make and push remote branch to $ORIGIN" R
+	parse_start_args "$@"
 	require_name_arg
 
 	# sanity checks
@@ -203,6 +219,15 @@ cmd_start() {
 	# update the local repo with remote changes, if asked
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
+	elif flag pull; then
+		git_pull $DEVELOP_BRANCH
+	fi
+
+	if flag remote; then
+		git_pull_quiet "$DEVELOP_BRANCH"
+		if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+			die "$BRANCH has already existed at $ORIGIN"
+		fi
 	fi
 
 	# if the origin branch counterpart exists, assert that the local branch
@@ -215,10 +240,21 @@ cmd_start() {
 	if ! git checkout -b "$BRANCH" "$BASE"; then
 		die "Could not create feature branch '$BRANCH'"
 	fi
+	# create remote branch
+	if flag remote && ! git push --set-upstream "$ORIGIN" "$BRANCH"; then
+		die "Could not create remote branch '$BRANCH' at '$ORIGIN'"
+	fi
 
 	echo
 	echo "Summary of actions:"
+	if flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$DEVELOP_BRANCH'"
+	fi
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
+	if flag remote; then
+		echo "- A new remote branch '$BRANCH' was created at '$ORIGIN', too"
+		echo "- The local branch '$BRANCH' was configured to track the remote branch"
+	fi
 	echo "- You are now on branch '$BRANCH'"
 	echo ""
 	echo "Now, start committing on your feature. When done, use:"
@@ -229,6 +265,8 @@ cmd_start() {
 
 cmd_finish() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
+	DEFINE_boolean pull true "pull from $ORIGIN before performing finish" P
+	DEFINE_boolean remote false "push the develop branch to remote and remove a remote feature branch at $ORIGIN" R
 	DEFINE_boolean rebase false "rebase instead of merge" r
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	parse_args "$@"
@@ -285,7 +323,12 @@ cmd_finish() {
 		if flag fetch; then
 			git fetch -q "$ORIGIN" "$BRANCH"
 			git fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
+		elif flag pull || flag remote; then
+			git_pull_quiet "$BRANCH"
+			git_pull_quiet "$DEVELOP_BRANCH"
 		fi
+	elif flag remote; then
+		die "not exist the remote $BRANCH branch at $ORIGIN"
 	fi
 
 	if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
@@ -296,14 +339,12 @@ cmd_finish() {
 	fi
 
 	# if the user wants to rebase, do that first
-	if flag rebase; then
-		if ! git flow feature rebase "$NAME" "$DEVELOP_BRANCH"; then
-			warn "Finish was aborted due to conflicts during rebase."
-			warn "Please finish the rebase manually now."
-			warn "When finished, re-run:"
-			warn "    git flow feature finish '$NAME' '$DEVELOP_BRANCH'"
-			exit 1
-		fi
+	if flag rebase && ! git flow feature rebase "$NAME" "$DEVELOP_BRANCH"; then
+		warn "Finish was aborted due to conflicts during rebase."
+		warn "Please finish the rebase manually now."
+		warn "When finished, re-run:"
+		warn "    git flow feature finish '$NAME' '$DEVELOP_BRANCH'"
+		exit 1
 	fi
 
 	# merge into BASE
@@ -343,20 +384,40 @@ helper_finish_cleanup() {
 	if flag fetch; then
 		git push "$ORIGIN" ":refs/heads/$BRANCH"
 	fi
-	
-	
+	if flag remote; then
+		git push "$ORIGIN" "$DEVELOP_BRANCH"
+	fi
+
 	if noflag keep; then
+		if [ "$BRANCH" = "$(git_current_branch)" ]; then
+			git checkout "$DEVELOP_BRANCH"
+		fi
+		if flag remote; then
+			git push "$ORIGIN" ":$BRANCH"
+		fi
 		git branch -d "$BRANCH"
 	fi
 
+
 	echo
 	echo "Summary of actions:"
+	if flag fetch; then
+		echo "- Latest objects have been fetched from '$ORIGIN'"
+	elif flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$DEVELOP_BRANCH'"
+	fi
 	echo "- The feature branch '$BRANCH' was merged into '$DEVELOP_BRANCH'"
 	#echo "- Merge conflicts were resolved"		# TODO: Add this line when it's supported
+	if flag remote; then
+		echo "- '$DEVELOP_BRANCH' have been pushed to '$ORIGIN'"
+	fi
 	if flag keep; then
 		echo "- Feature branch '$BRANCH' is still available"
 	else
 		echo "- Feature branch '$BRANCH' has been removed"
+		if flag remote; then
+			echo "- Feature branch '$BRANCH' in '$ORIGIN' has been deleted."
+		fi
 	fi
 	echo "- You are now on branch '$DEVELOP_BRANCH'"
 	echo
@@ -505,3 +566,5 @@ cmd_pull() {
 		echo "Created local branch $BRANCH based on $REMOTE's $BRANCH."
 	fi
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -44,8 +44,14 @@ PREFIX=$(git config --get gitflow.prefix.hotfix)
 
 usage() {
 	echo "usage: git flow hotfix [list] [-v]"
-	echo "       git flow hotfix start [-F] <version> [<base>]"
-	echo "       git flow hotfix finish [-Fsumpk] <version>"
+	echo "       git flow hotfix start [-F|--fetch] [-P|--pull] <version> [<base>]"
+	echo "       git flow hotfix start [-R|--remote] <version> [<base>]"
+	echo "       git flow hotfix finish [-F|--fetch] [-P|--pull]"
+	echo "                              [-s|--sign] [-u|--signingkey] [-m|--message]"
+	echo "                              [-p|--push] [-n|--notag] [-k|--keep] <version>"
+	echo "       git flow hotfix finish [-R|--remote]"
+	echo "                              [-s|--sign] [-u|--signingkey] [-m|--message]"
+	echo "                              [-p|--push] [-n|--notag] [-k|--keep] <version>"
 }
 
 cmd_default() {
@@ -62,11 +68,11 @@ cmd_list() {
 	hotfix_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
 	if [ -z "$hotfix_branches" ]; then
 		warn "No hotfix branches exist."
-                warn ""
-                warn "You can start a new hotfix branch:"
-                warn ""
-                warn "    git flow hotfix start <version> [<base>]"
-                warn ""
+		warn ""
+		warn "You can start a new hotfix branch:"
+		warn ""
+		warn "    git flow hotfix start <version> [<base>]"
+		warn ""
 		exit 0
 	fi
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
@@ -128,6 +134,17 @@ parse_args() {
 	BRANCH=$PREFIX$VERSION
 }
 
+parse_start_args() {
+	# parse options
+	FLAGS "$@" || exit $?
+	eval set -- "${FLAGS_ARGV}"
+
+	# read arguments into global variables
+	VERSION=$1
+	BRANCH=$PREFIX$VERSION
+	BASE=${2:-$MASTER_BRANCH}
+}
+
 require_version_arg() {
 	if [ "$VERSION" = "" ]; then
 		warn "Missing argument <version>"
@@ -138,10 +155,10 @@ require_version_arg() {
 
 require_base_is_on_master() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
-			| sed 's/[* ] //g' \
-	  		| grep -q "^$MASTER_BRANCH\$"; then
-		die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
-	fi
+		| sed 's/[* ] //g' \
+		| grep -q "^$MASTER_BRANCH\$"; then
+	die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+fi
 }
 
 require_no_existing_hotfix_branches() {
@@ -154,8 +171,9 @@ require_no_existing_hotfix_branches() {
 
 cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
-	parse_args "$@"
-	BASE=${2:-$MASTER_BRANCH}
+	DEFINE_boolean pull true "pull from $ORIGIN before performing local operation" P
+	DEFINE_boolean remote false "make and push remote branch to $ORIGIN" R
+	parse_start_args "$@"
 	require_version_arg
 	require_base_is_on_master
 	require_no_existing_hotfix_branches
@@ -166,17 +184,39 @@ cmd_start() {
 	require_tag_absent "$VERSION_PREFIX$VERSION"
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$MASTER_BRANCH"
+	elif flag pull; then
+		git_pull_quiet "$MASTER_BRANCH"
 	fi
+	if flag remote; then
+		git_pull_quiet "$MASTER_BRANCH"
+		if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+			die "$BRANCH has already existed at $ORIGIN"
+		fi
+	fi
+
 	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
 	fi
 
 	# create branch
 	git checkout -b "$BRANCH" "$BASE"
+	# create remote branch
+	if flag remote && ! git push --set-upstream "$ORIGIN" "$BRANCH"; then
+		die "Could not create remote branch '$BRANCH' at '$ORIGIN'"
+	fi
 
 	echo
 	echo "Summary of actions:"
+	if flag fetch; then
+		echo "- Latest objects have been fetched from '$ORIGIN'"
+	elif flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$MASTER_BRANCH'"
+	fi
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
+	if flag remote; then
+		echo "- A new remote branch '$BRANCH' was created at '$ORIGIN', too"
+		echo "- The local branch '$BRANCH' was configured to track the remote branch"
+	fi
 	echo "- You are now on branch '$BRANCH'"
 	echo
 	echo "Follow-up actions:"
@@ -190,6 +230,8 @@ cmd_start() {
 
 cmd_finish() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
+	DEFINE_boolean pull true "pull from $ORIGIN before performing local operation" P
+	DEFINE_boolean remote false "push the master/develop to remote and remove a remote hotfix branch at $ORIGIN" R
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
@@ -209,9 +251,12 @@ cmd_finish() {
 	require_clean_working_tree
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$MASTER_BRANCH" || \
-		  die "Could not fetch $MASTER_BRANCH from $ORIGIN."
+			die "Could not fetch $MASTER_BRANCH from $ORIGIN."
 		git fetch -q "$ORIGIN" "$DEVELOP_BRANCH" || \
-		  die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
+			die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
+	elif flag pull || flag remote; then
+		git_pull_quiet "$MASTER_BRANCH"
+		git_pull_quiet "$DEVELOP_BRANCH"
 	fi
 	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
@@ -219,16 +264,19 @@ cmd_finish() {
 	if has "$ORIGIN/$DEVELOP_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
+	if flag remote && ! has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+		die "not exist the remote $BRANCH branch at $ORIGIN"
+	fi
 
 	# try to merge into master
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
-		  die "Could not check out $MASTER_BRANCH."
+			die "Could not check out $MASTER_BRANCH."
 		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+			die "There were merge conflicts."
+		# TODO: What do we do now?
 	fi
 
 	if noflag notag; then
@@ -242,7 +290,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			git tag $opts "$VERSION_PREFIX$VERSION" || \
-			die "Tagging failed. Please run finish again to retry."
+				die "Tagging failed. Please run finish again to retry."
 		fi
 	fi
 
@@ -251,21 +299,27 @@ cmd_finish() {
 	# but the merge into develop was successful, we skip it now
 	if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
 		git checkout "$DEVELOP_BRANCH" || \
-		  die "Could not check out $DEVELOP_BRANCH."
+			die "Could not check out $DEVELOP_BRANCH."
 
 		# TODO: Actually, accounting for 'git describe' pays, so we should
 		# ideally git merge --no-ff $tagname here, instead!
 		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+			die "There were merge conflicts."
+		# TODO: What do we do now?
 	fi
 
 	# delete branch
 	if noflag keep; then
+		if [ "$BRANCH" = "$(git_current_branch)" ]; then
+			git checkout "$MASTER_BRANCH"
+		fi
+		if flag remote; then
+			git push "$ORIGIN" ":$BRANCH"
+		fi
 		git branch -d "$BRANCH"
 	fi
 
-	if flag push; then
+	if flag push || flag remote; then
 		git push "$ORIGIN" "$DEVELOP_BRANCH" || \
 			die "Could not push to $DEVELOP_BRANCH from $ORIGIN."
 		git push "$ORIGIN" "$MASTER_BRANCH" || \
@@ -278,7 +332,12 @@ cmd_finish() {
 
 	echo
 	echo "Summary of actions:"
-	echo "- Latest objects have been fetched from '$ORIGIN'"
+	if flag fetch; then
+		echo "- Latest objects have been fetched from '$ORIGIN'"
+	elif flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$MASTER_BRANCH'"
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$DEVELOP_BRANCH'"
+	fi
 	echo "- Hotfix branch has been merged into '$MASTER_BRANCH'"
 	if noflag notag; then
 		echo "- The hotfix was tagged '$VERSION_PREFIX$VERSION'"
@@ -288,9 +347,14 @@ cmd_finish() {
 		echo "- Hotfix branch '$BRANCH' is still available"
 	else
 		echo "- Hotfix branch '$BRANCH' has been deleted"
+		if flag remote; then
+			echo "- Hotfix branch '$BRANCH' in '$ORIGIN' has been deleted."
+		fi
 	fi
-	if flag push; then
+	if flag push || flag remote; then
 		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
 	echo
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-init
+++ b/git-flow-init
@@ -51,7 +51,7 @@ cmd_default() {
 	DEFINE_boolean force false 'force setting of gitflow branches, even if already configured' f
 	DEFINE_boolean defaults false 'use default branch naming conventions' d
 	parse_args "$@"
-	
+
 	if ! git rev-parse --git-dir >/dev/null 2>&1; then
 		git init
 	else
@@ -69,9 +69,9 @@ cmd_default() {
 	local branch_count
 	local answer
 
-    if flag defaults; then
-        warn "Using default branch names."
-    fi
+	if flag defaults; then
+		warn "Using default branch names."
+	fi
 
 	# add a master branch if no such branch exists yet
 	local master_branch
@@ -99,81 +99,81 @@ cmd_default() {
 			should_check_existence=YES
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.master) \
-			             'production' 'main' 'master'; do
-				if git_local_branch_exists "$guess"; then
-					default_suggestion="$guess"
-					break
-				fi
-			done
-		fi
-		
-		printf "Branch name for production releases: [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		master_branch=${answer:-$default_suggestion}
-
-		# check existence in case of an already existing repo
-		if [ "$should_check_existence" = "YES" ]; then
-			git_local_branch_exists "$master_branch" || \
-				die "Local branch '$master_branch' does not exist."
-		fi
-
-		# store the name of the master branch
-		git config gitflow.branch.master "$master_branch"
+				'production' 'main' 'master'; do
+			if git_local_branch_exists "$guess"; then
+				default_suggestion="$guess"
+				break
+			fi
+		done
 	fi
 
-	# add a develop branch if no such branch exists yet
-	local develop_branch
-	if gitflow_has_develop_configured && ! flag force; then
-		develop_branch=$(git config --get gitflow.branch.develop)
+	printf "Branch name for production releases: [$default_suggestion] "
+	if noflag defaults; then
+		read answer
 	else
-		# Again, the same two cases as with the master selection are
-		# considered (fresh repo or repo that contains branches)
-		local default_suggestion
-		local should_check_existence
-		branch_count=$(git_local_branches | grep -v "^${master_branch}\$" | wc -l)
-		if [ "$branch_count" -eq 0 ]; then
-			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
-		else
-			echo
-			echo "Which branch should be used for integration of the \"next release\"?"
-			git_local_branches | grep -v "^${master_branch}\$" | sed 's/^.*$/   - &/g'
+		printf "\n"
+	fi
+	master_branch=${answer:-$default_suggestion}
 
-			should_check_existence=YES
-			default_suggestion=
-			for guess in $(git config --get gitflow.branch.develop) \
-			             'develop' 'int' 'integration' 'master'; do
-				if git_local_branch_exists "$guess"; then
-					default_suggestion="$guess"
-					break
-				fi
-			done
+	# check existence in case of an already existing repo
+	if [ "$should_check_existence" = "YES" ]; then
+		git_local_branch_exists "$master_branch" || \
+			die "Local branch '$master_branch' does not exist."
+	fi
+
+	# store the name of the master branch
+	git config gitflow.branch.master "$master_branch"
+fi
+
+# add a develop branch if no such branch exists yet
+local develop_branch
+if gitflow_has_develop_configured && ! flag force; then
+	develop_branch=$(git config --get gitflow.branch.develop)
+else
+	# Again, the same two cases as with the master selection are
+	# considered (fresh repo or repo that contains branches)
+	local default_suggestion
+	local should_check_existence
+	branch_count=$(git_local_branches | grep -v "^${master_branch}\$" | wc -l)
+	if [ "$branch_count" -eq 0 ]; then
+		should_check_existence=NO
+		default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
+	else
+		echo
+		echo "Which branch should be used for integration of the \"next release\"?"
+		git_local_branches | grep -v "^${master_branch}\$" | sed 's/^.*$/   - &/g'
+
+		should_check_existence=YES
+		default_suggestion=
+		for guess in $(git config --get gitflow.branch.develop) \
+			'develop' 'int' 'integration' 'master'; do
+		if git_local_branch_exists "$guess"; then
+			default_suggestion="$guess"
+			break
 		fi
+	done
+fi
 
-		printf "Branch name for \"next release\" development: [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		develop_branch=${answer:-$default_suggestion}
+printf "Branch name for \"next release\" development: [$default_suggestion] "
+if noflag defaults; then
+	read answer
+else
+	printf "\n"
+fi
+develop_branch=${answer:-$default_suggestion}
 
-		if [ "$master_branch" = "$develop_branch" ]; then
-			die "Production and integration branches should differ."
-		fi
+if [ "$master_branch" = "$develop_branch" ]; then
+	die "Production and integration branches should differ."
+fi
 
-		# check existence in case of an already existing repo
-		if [ "$should_check_existence" = "YES" ]; then
-			git_local_branch_exists "$develop_branch" || \
-				die "Local branch '$develop_branch' does not exist."
-		fi
+# check existence in case of an already existing repo
+if [ "$should_check_existence" = "YES" ]; then
+	git_local_branch_exists "$develop_branch" || \
+		die "Local branch '$develop_branch' does not exist."
+fi
 
-		# store the name of the develop branch
-		git config gitflow.branch.develop "$develop_branch"
+# store the name of the develop branch
+git config gitflow.branch.develop "$develop_branch"
 	fi
 
 	# Creation of HEAD
@@ -214,85 +214,131 @@ cmd_default() {
 
 	# finally, ask the user for naming conventions (branch and tag prefixes)
 	if flag force || \
-	   ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.support >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1; then
+		! git config --get gitflow.prefix.feature >/dev/null 2>&1 || 
+	! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
+	! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
+	! git config --get gitflow.prefix.support >/dev/null 2>&1 || 
+	! git config --get gitflow.prefix.versiontag >/dev/null 2>&1; then
+	echo
+	echo "How to name your supporting branch prefixes?"
+fi
+
+local prefix
+
+# Feature branches
+if ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
+	default_suggestion=$(git config --get gitflow.prefix.feature || echo feature/)
+	printf "Feature branches? [$default_suggestion] "
+	if noflag defaults; then
+		read answer
+	else
+		printf "\n"
+	fi
+	[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+	git config gitflow.prefix.feature "$prefix"
+fi
+
+# Release branches
+if ! git config --get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
+	default_suggestion=$(git config --get gitflow.prefix.release || echo release/)
+	printf "Release branches? [$default_suggestion] "
+	if noflag defaults; then
+		read answer
+	else
+		printf "\n"
+	fi
+	[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+	git config gitflow.prefix.release "$prefix"
+fi
+
+
+# Hotfix branches
+if ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
+	default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix/)
+	printf "Hotfix branches? [$default_suggestion] "
+	if noflag defaults; then
+		read answer
+	else
+		printf "\n"
+	fi
+	[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+	git config gitflow.prefix.hotfix "$prefix"
+fi
+
+
+# Support branches
+if ! git config --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
+	default_suggestion=$(git config --get gitflow.prefix.support || echo support/)
+	printf "Support branches? [$default_suggestion] "
+	if noflag defaults; then
+		read answer
+	else
+		printf "\n"
+	fi
+	[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+	git config gitflow.prefix.support "$prefix"
+fi
+
+
+# Version tag prefix
+if ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
+	default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "")
+	printf "Version tag prefix? [$default_suggestion] "
+	if noflag defaults; then
+		read answer
+	else
+		printf "\n"
+	fi
+	[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+	git config gitflow.prefix.versiontag "$prefix"
+fi
+
+# add a remote repository name if no such remote repository exists yet
+local remote_repo
+if gitflow_has_remote_configured && ! flag force; then
+	remote_repo=$(git config --get gitflow.remote)
+else
+	# Again, the same two cases as with the master selection are
+	# considered (fresh repo or repo that contains branches)
+	local default_suggestion
+	local should_check_existence
+	remote_count=$(git remote | wc -l)
+	if [ "$remote_count" -ne 0 ]; then
+		should_check_existence=NO
+		default_suggestion="origin"
+	else
 		echo
-		echo "How to name your supporting branch prefixes?"
-	fi
+		echo "Which default remote repository should be used to push?"
+		git remote | sed 's/^.*$/   - &/g'
 
-	local prefix
-
-	# Feature branches
-	if ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature/)
-		printf "Feature branches? [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
+		should_check_existence=YES
+		default_suggestion=
+		for guess in $(git config --get gitflow.remote) \
+			'origin' 'github' 'work' 'private'; do
+		if git_remote_exists "$guess"; then
+			default_suggestion="$guess"
+			break
 		fi
-		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.feature "$prefix"
+	done
+fi
+
+printf "Remote repository to push: [$default_suggestion] "
+if noflag defaults; then
+	read answer
+else
+	printf "\n"
+fi
+remote_repo=${answer:-$default_suggestion}
+
+# check existence in case of an already existing repo
+if [ "$should_check_existence" = "YES" ]; then
+	git_remote_exists "$remote_repo" || \
+		die "Remote repository '$remote_repo' does not exist."
+fi
+
+# store the name of the develop branch
+git config gitflow.remote "$remote_repo"
 	fi
-
-	# Release branches
-	if ! git config --get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.release || echo release/)
-		printf "Release branches? [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.release "$prefix"
-	fi
-
-
-	# Hotfix branches
-	if ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix/)
-		printf "Hotfix branches? [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.hotfix "$prefix"
-	fi
-
-
-	# Support branches
-	if ! git config --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.support || echo support/)
-		printf "Support branches? [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.support "$prefix"
-	fi
-
-
-	# Version tag prefix
-	if ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "")
-		printf "Version tag prefix? [$default_suggestion] "
-		if noflag defaults; then
-			read answer
-		else
-			printf "\n"
-		fi
-		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.versiontag "$prefix"
-	fi
-
 
 	# TODO: what to do with origin?
 }
@@ -301,3 +347,5 @@ cmd_help() {
 	usage
 	exit 0
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-release
+++ b/git-flow-release
@@ -44,8 +44,14 @@ PREFIX=$(git config --get gitflow.prefix.release)
 
 usage() {
 	echo "usage: git flow release [list] [-v]"
-	echo "       git flow release start [-F] <version> [<base>]"
-	echo "       git flow release finish [-Fsumpk] <version>"
+	echo "       git flow release start [-F|--fetch] [-P|--pull] <version> [<base>]"
+	echo "       git flow release start [-R|--remote] <version> [<base>]"
+	echo "       git flow release finish [-F|--fetch] [-P|--pull]"
+	echo "                               [-s|--sign] [-u|--signingkey] [-m|--message]"
+	echo "                               [-p|--push] [-n|--notag] [-k|--keep] <version>"
+	echo "       git flow release finish [-R|--remote]"
+	echo "                               [-s|--sign] [-u|--signingkey] [-m|--message]"
+	echo "                               [-p|--push] [-n|--notag] [-k|--keep] <version>"
 	echo "       git flow release publish <name>"
 	echo "       git flow release track <name>"
 }
@@ -64,11 +70,11 @@ cmd_list() {
 	release_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
 	if [ -z "$release_branches" ]; then
 		warn "No release branches exist."
-                warn ""
-                warn "You can start a new release branch:"
-                warn ""
-                warn "    git flow release start <name> [<base>]"
-                warn ""
+		warn ""
+		warn "You can start a new release branch:"
+		warn ""
+		warn "    git flow release start <name> [<base>]"
+		warn ""
 		exit 0
 	fi
 
@@ -125,6 +131,17 @@ parse_args() {
 	BRANCH=$PREFIX$VERSION
 }
 
+parse_start_args() {
+	# parse options
+	FLAGS "$@" || exit $?
+	eval set -- "${FLAGS_ARGV}"
+
+	# read arguments into global variables
+	VERSION=$1
+	BRANCH=$PREFIX$VERSION
+	BASE=${2:-$DEVELOP_BRANCH}
+}
+
 require_version_arg() {
 	if [ "$VERSION" = "" ]; then
 		warn "Missing argument <version>"
@@ -135,10 +152,10 @@ require_version_arg() {
 
 require_base_is_on_develop() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
-			| sed 's/[* ] //g' \
-	  		| grep -q "^$DEVELOP_BRANCH\$"; then
-		die "fatal: Given base '$BASE' is not a valid commit on '$DEVELOP_BRANCH'."
-	fi
+		| sed 's/[* ] //g' \
+		| grep -q "^$DEVELOP_BRANCH\$"; then
+	die "fatal: Given base '$BASE' is not a valid commit on '$DEVELOP_BRANCH'."
+fi
 }
 
 require_no_existing_release_branches() {
@@ -151,8 +168,9 @@ require_no_existing_release_branches() {
 
 cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
-	parse_args "$@"
-	BASE=${2:-$DEVELOP_BRANCH}
+	DEFINE_boolean pull true "pull from $ORIGIN before performing local operation" P
+	DEFINE_boolean remote false "make and push remote branch to $ORIGIN" R
+	parse_start_args "$@"
 	require_version_arg
 	require_base_is_on_develop
 	require_no_existing_release_branches
@@ -163,17 +181,40 @@ cmd_start() {
 	require_tag_absent "$VERSION_PREFIX$VERSION"
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
+	elif flag pull; then
+		git_pull_quiet "$DEVELOP_BRANCH"
 	fi
+
+	if flag remote; then
+		git_pull_quiet "$DEVELOP_BRANCH"
+		if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+			die "$BRANCH has already existed at $ORIGIN"
+		fi
+	fi
+
 	if has "$ORIGIN/$DEVELOP_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
 	# create branch
 	git checkout -b "$BRANCH" "$BASE"
+	# create remote branch
+	if flag remote && ! git push --set-upstream "$ORIGIN" "$BRANCH"; then
+		die "Could not create remote branch '$BRANCH' at '$ORIGIN'"
+	fi
 
 	echo
 	echo "Summary of actions:"
+	if flag fetch; then
+		echo "- Latest objects have been fetched from '$ORIGIN'"
+	elif flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$DEVELOP_BRANCH'"
+	fi
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
+	if flag remote; then
+		echo "- A new remote branch '$BRANCH' was created at '$ORIGIN', too"
+		echo "- The local branch '$BRANCH' was configured to track the remote branch"
+	fi
 	echo "- You are now on branch '$BRANCH'"
 	echo
 	echo "Follow-up actions:"
@@ -187,6 +228,7 @@ cmd_start() {
 
 cmd_finish() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
+	DEFINE_boolean remote false "push the master/develop to remote and remove a remote hotfix branch at $ORIGIN" R
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
@@ -207,9 +249,12 @@ cmd_finish() {
 	require_clean_working_tree
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$MASTER_BRANCH" || \
-		  die "Could not fetch $MASTER_BRANCH from $ORIGIN."
+			die "Could not fetch $MASTER_BRANCH from $ORIGIN."
 		git fetch -q "$ORIGIN" "$DEVELOP_BRANCH" || \
-		  die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
+			die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
+	elif flag pull || flag remote; then
+		git_pull_quiet "$MASTER_BRANCH"
+		git_pull_quiet "$DEVELOP_BRANCH"
 	fi
 	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
@@ -217,16 +262,19 @@ cmd_finish() {
 	if has "$ORIGIN/$DEVELOP_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
+	if flag remote && ! has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+		die "not exist the remote $BRANCH branch at $ORIGIN"
+	fi
 
 	# try to merge into master
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
-		  die "Could not check out $MASTER_BRANCH."
+			die "Could not check out $MASTER_BRANCH."
 		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+			die "There were merge conflicts."
+		# TODO: What do we do now?
 	fi
 
 	if noflag notag; then
@@ -240,7 +288,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			git tag $opts "$tagname" || \
-			die "Tagging failed. Please run finish again to retry."
+				die "Tagging failed. Please run finish again to retry."
 		fi
 	fi
 
@@ -249,13 +297,13 @@ cmd_finish() {
 	# but the merge into develop was successful, we skip it now
 	if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
 		git checkout "$DEVELOP_BRANCH" || \
-		  die "Could not check out $DEVELOP_BRANCH."
+			die "Could not check out $DEVELOP_BRANCH."
 
 		# TODO: Actually, accounting for 'git describe' pays, so we should
 		# ideally git merge --no-ff $tagname here, instead!
 		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+			die "There were merge conflicts."
+		# TODO: What do we do now?
 	fi
 
 	# delete branch
@@ -263,17 +311,20 @@ cmd_finish() {
 		if [ "$BRANCH" = "$(git_current_branch)" ]; then
 			git checkout "$MASTER_BRANCH"
 		fi
+		if flag remote; then
+			git push $ORIGIN $BRANCH
+		fi
 		git branch -d "$BRANCH"
 	fi
 
-	if flag push; then
+	if flag push || flag remote; then
 		git push "$ORIGIN" "$DEVELOP_BRANCH" || \
 			die "Could not push to $DEVELOP_BRANCH from $ORIGIN."
 		git push "$ORIGIN" "$MASTER_BRANCH" || \
 			die "Could not push to $MASTER_BRANCH from $ORIGIN."
 		if noflag notag; then
 			git push --tags "$ORIGIN" || \
-			  die "Could not push tags to $ORIGIN."
+				die "Could not push tags to $ORIGIN."
 		fi
 		git push "$ORIGIN" :"$BRANCH" || \
 			die "Could not delete the remote $BRANCH in $ORIGIN."
@@ -281,7 +332,12 @@ cmd_finish() {
 
 	echo
 	echo "Summary of actions:"
-	echo "- Latest objects have been fetched from '$ORIGIN'"
+	if flag fetch; then
+		echo "- Latest objects have been fetched from '$ORIGIN'"
+	elif flag pull || flag remote; then
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$MASTER_BRANCH'"
+		echo "- Latest objects have been pulled from '$ORIGIN' to '$DEVELOP_BRANCH'"
+	fi
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
@@ -292,7 +348,7 @@ cmd_finish() {
 	else
 		echo "- Release branch '$BRANCH' has been deleted"
 	fi
-	if flag push; then
+	if flag push || flag remote; then
 		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
 		echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
 	fi
@@ -345,3 +401,5 @@ cmd_track() {
 	echo "- You are now on branch '$BRANCH'"
 	echo
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-support
+++ b/git-flow-support
@@ -64,11 +64,11 @@ cmd_list() {
 	support_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
 	if [ -z "$support_branches" ]; then
 		warn "No support branches exist."
-                warn ""
-                warn "You can start a new support branch:"
-                warn ""
-                warn "    git flow support start <name> <base>"
-                warn ""
+		warn ""
+		warn "You can start a new support branch:"
+		warn ""
+		warn "    git flow support start <name> <base>"
+		warn ""
 		exit 0
 	fi
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
@@ -149,10 +149,10 @@ require_base_arg() {
 
 require_base_is_on_master() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
-			| sed 's/[* ] //g' \
-	  		| grep -q "^$MASTER_BRANCH\$"; then
-		die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
-	fi
+		| sed 's/[* ] //g' \
+		| grep -q "^$MASTER_BRANCH\$"; then
+	die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+fi
 }
 
 cmd_start() {
@@ -180,3 +180,5 @@ cmd_start() {
 	echo "- You are now on branch '$BRANCH'"
 	echo
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow-version
+++ b/git-flow-version
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-GITFLOW_VERSION=0.4.2-pre
+GITFLOW_VERSION=0.5.10-pre
 
 usage() {
 	echo "usage: git flow version"
@@ -50,3 +50,5 @@ cmd_help() {
 	usage
 	exit 0
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :

--- a/git-flow.rb
+++ b/git-flow.rb
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+require 'formula'
+
+class GitFlowCompletion < Formula
+  url 'https://github.com/iwata/git-flow-completion.git', :tag => '0.5.4.0'
+  version '0.5.4.0'
+  head 'https://github.com/iwata/git-flow-completion.git', :branch => 'develop'
+
+  def initialize
+    # We need to hard-code the formula name since Homebrew can't
+    # deduce it from the formula's filename, and the git download
+    # strategy really needs a valid name.
+
+    super "git-flow-completion"
+  end
+
+  homepage 'https://github.com/iwata/git-flow-completion'
+end
+
+class GitFlow < Formula
+  url 'https://github.com/iwata/gitflow.git', :tag => '0.5.14.0'
+  version '0.5.14.0'
+  head 'https://github.com/iwata/gitflow.git', :branch => 'develop'
+
+  homepage 'https://github.com/iwata/gitflow'
+
+  def patches
+    DATA
+  end
+
+  def options
+    [
+        ['--bash-completion', "copy bash completion function file to #{prefix}/etc/bash_completion.d"],
+        ['--zsh-completion', "copy zsh completion function file to #{share}/zsh/functions: please add #{share}/zsh/functions to $fpath in .zshrc"]
+    ]
+  end
+
+  # for longopt
+  depends_on 'gnu-getopt'
+
+  def install
+    system "make", "prefix=#{prefix}", "install"
+
+    # Normally, etc files are installed directly into HOMEBREW_PREFIX,
+    # rather than being linked from the Cellar — this is so that
+    # configuration files don't get clobbered when you update.  The
+    # bash-completion file isn't really configuration, though; it
+    # should be updated when we upgrade the package.
+
+    cellar_etc = prefix + 'etc'
+    bash_completion_d = cellar_etc + "bash_completion.d"
+    zsh_functions_d = share + 'zsh/functions'
+
+    completion = GitFlowCompletion.new
+    completion.brew do
+      bash_completion_d.install "git-flow-completion.bash" if ARGV.include? '--bash-completion'
+      zsh_functions_d.install "_git-flow" if ARGV.include? '--zsh-completion'
+    end
+  end
+end
+
+#This patch makes sure GNUtools are used on OSX.
+#gnu-getopt is keg-only hence the backtick expansion.
+#These aliases only exist for the duration of git-now,
+#inside the git-flow shells. Normal operation of bash is
+#unaffected - getopt will still find the version supplied
+#by OSX in other shells, for example.
+__END__
+--- a/git-flow
++++ b/git-flow
+@@ -37,6 +37,8 @@
+ # policies, either expressed or implied, of Vincent Driessen.
+ #
+ 
++alias getopt='`brew --prefix gnu-getopt`/bin/getopt'
++
+ # enable debug mode
+ if [ "$DEBUG" = "yes" ]; then
+        set -x

--- a/gitflow-common
+++ b/gitflow-common
@@ -105,6 +105,17 @@ git_tag_exists() {
 	has $1 $(git_all_tags)
 }
 
+git_remote_exists() {
+	has $1 $(git remote)
+}
+
+git_pull_quiet() {
+	local branch=$1
+	git checkout $branch
+	git pull -q || \
+		die "Could not pull '$branch' from $ORIGIN";
+}
+
 #
 # git_compare_branches()
 #
@@ -165,18 +176,23 @@ gitflow_has_develop_configured() {
 
 gitflow_has_prefixes_configured() {
 	git config --get gitflow.prefix.feature >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.release >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
-	git config --get gitflow.prefix.support >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.versiontag >/dev/null 2>&1
+		git config --get gitflow.prefix.release >/dev/null 2>&1     && \
+		git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
+		git config --get gitflow.prefix.support >/dev/null 2>&1     && \
+		git config --get gitflow.prefix.versiontag >/dev/null 2>&1
+}
+
+gitflow_has_remote_configured() {
+	local remote=$(git config --get gitflow.remote)
+	[ "$remote" != "" ] && git_remote_exists "$remote"
 }
 
 gitflow_is_initialized() {
 	gitflow_has_master_configured                    && \
-	gitflow_has_develop_configured                   && \
-	[ "$(git config --get gitflow.branch.master)" !=    \
-	  "$(git config --get gitflow.branch.develop)" ] && \
-	gitflow_has_prefixes_configured
+		gitflow_has_develop_configured                   && \
+		[ "$(git config --get gitflow.branch.master)" !=    \
+		"$(git config --get gitflow.branch.develop)" ] && \
+		gitflow_has_prefixes_configured
 }
 
 # loading settings that can be overridden using git config
@@ -184,7 +200,7 @@ gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
-	export ORIGIN=$(git config --get gitflow.origin || echo origin)
+	export ORIGIN=$(git config --get gitflow.remote || echo origin)
 }
 
 #
@@ -312,3 +328,5 @@ require_branches_equal() {
 		fi
 	fi
 }
+
+# vim: set noexpandtab ff=unix ft=sh sts=0 :


### PR DESCRIPTION
Firstly, I created '-R' option that another publishing method to remote repository.
Hotfix, feature, release subcommands have the option.
If you execute 'start' or 'finish' with it, you could push 'develop' or 'master' branch and delete branch at 'origin' repository.

Secondly, the '-p' option have been pulled from 'origin' to 'develop' or 'master' before performing finish.

And making homebrew's formula that dependent on gnu-getopt.
