### PR TITLE
develop_branch uses origin/develop_branch as start-point if one exists.

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -200,7 +200,11 @@ cmd_default() {
 	# default production branch and develop was "created".  We should create
 	# the develop branch now in that case (we base it on master, of course)
 	if ! git_local_branch_exists "$develop_branch"; then
-		git branch --no-track "$develop_branch" "$master_branch"
+		if git_remote_branch_exists "origin/$develop_branch"; then
+			git branch "$develop_branch" "origin/$develop_branch" >/dev/null 2>&1
+		else
+			git branch --no-track "$develop_branch" "$master_branch"
+		fi
 		created_gitflow_branch=1
 	fi
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -97,6 +97,10 @@ git_local_branch_exists() {
 	has $1 $(git_local_branches)
 }
 
+git_remote_branch_exists() {
+	has $1 $(git_remote_branches)
+}
+
 git_branch_exists() {
 	has $1 $(git_all_branches)
 }


### PR DESCRIPTION
By default a local develop branch is created of from master regardless if a origin/develop exits. This problem is discussed in issues #137 and #23.
