### PR TITLE
Track remote master branch if local master doesn't exist

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -117,8 +117,14 @@ cmd_default() {
 
 		# check existence in case of an already existing repo
 		if [ "$should_check_existence" = "YES" ]; then
-			git_local_branch_exists "$master_branch" || \
+			# if no local branch exists and a remote branch of the same
+			# name exists, checkout that branch and use it for master
+			if ! git_local_branch_exists "$master_branch" && \
+				git_remote_branch_exists "origin/$master_branch"; then
+				git branch "$master_branch" "origin/$master_branch" >/dev/null 2>&1
+			elif ! git_local_branch_exists "$master_branch"; then
 				die "Local branch '$master_branch' does not exist."
+			fi
 		fi
 
 		# store the name of the master branch


### PR DESCRIPTION
Like #167, but for master branch.

For repositories that use the develop branch as the default branch (like gitflow itself), this would fix `git flow init` from breaking when the master branch is not present locally.
