### PR TITLE
Set submodule to use http and not git protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+  url = https://github.com/nvie/shFlags.git


### PR DESCRIPTION
A non-trivial number of corporate firewalls block port 9418. Setting the submodule to use http instead avoids broken installs.
