### PR TITLE
Allow user to specify the commit message for merges

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -313,8 +313,8 @@ cmd_finish() {
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		git merge --ff "$BRANCH"
 	else
-        local opts=""
-        [ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+		local opts=""
+		[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 		git merge --no-ff $opts "$BRANCH"
 	fi
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -44,7 +44,7 @@ PREFIX=$(git config --get gitflow.prefix.feature)
 usage() {
 	echo "usage: git flow feature [list] [-v]"
 	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFkD] [<name|nameprefix>]"
+	echo "       git flow feature finish [-rFkD] [-m <message>] [<name|nameprefix>]"
 	echo "       git flow feature publish <name>"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
@@ -232,6 +232,7 @@ cmd_finish() {
 	DEFINE_boolean rebase false "rebase instead of merge" r
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
+	DEFINE_string message "" "use the given commit message" m
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -312,7 +313,9 @@ cmd_finish() {
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		git merge --ff "$BRANCH"
 	else
-		git merge --no-ff "$BRANCH"
+        local opts=""
+        [ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+		git merge --no-ff $opts "$BRANCH"
 	fi
 
 	if [ $? -ne 0 ]; then

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -221,6 +221,7 @@ cmd_finish() {
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
+    DEFINE_string commit "" "use the given commit message" c
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
@@ -254,7 +255,9 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
+        local opts=""
+        [ "$FLAGS_commit" != "" ] && opts="$opts -m '$FLAGS_commit'"
+		git merge --no-ff $opts "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -221,7 +221,7 @@ cmd_finish() {
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
-    DEFINE_string commit "" "use the given commit message" c
+	DEFINE_string commit "" "use the given commit message" c
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
@@ -255,8 +255,8 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-        local opts=""
-        [ "$FLAGS_commit" != "" ] && opts="$opts -m '$FLAGS_commit'"
+		local opts=""
+		[ "$FLAGS_commit" != "" ] && opts="$opts -m '$FLAGS_commit'"
 		git merge --no-ff $opts "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -45,7 +45,7 @@ PREFIX=$(git config --get gitflow.prefix.hotfix)
 usage() {
 	echo "usage: git flow hotfix [list] [-v]"
 	echo "       git flow hotfix start [-F] <version> [<base>]"
-	echo "       git flow hotfix finish [-Fsumpk] <version>"
+	echo "       git flow hotfix finish [-Fsumpk] [-c <message>] <version>"
 	echo "       git flow hotfix publish <version>"
 }
 


### PR DESCRIPTION
My main use case is automatically closing Issues on github via commit messages referencing the issue number, e.g. `Fixed #1 - Some issue.` After testing several methods, I decided the method most consistent with gitflow was to change the commit message for the merge commits. I added a `-m,--message` option to `git flow feature finish`, but I opted to use `-c,--commit` for the commit message in `git flow hotfix finish` since the `-m,--message` flag is already used for the tag message.
