### PR TITLE
Issue #49: Be git-describe friendly by back-merging release branch/tag into development branch

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -224,6 +224,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)" b
 	parse_args "$@"
 	require_version_arg
 
@@ -275,17 +276,35 @@ cmd_finish() {
 	fi
 
 	# try to merge into develop
-	# in case a previous attempt to finish this release branch has failed,
-	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
-		git checkout "$DEVELOP_BRANCH" || \
-		  die "Could not check out $DEVELOP_BRANCH."
+	if noflag nobackmerge; then
+		# in case a previous attempt to finish this hotfix branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
 
-		# TODO: Actually, accounting for 'git describe' pays, so we should
-		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+			# merge the master branch back into develop; this makes the master
+			# branch - and the new tag (if provided) - a parent of the development
+			# branch, which in turn lets you use 'git describe' on either branch
+			if noflag notag; then
+			  git merge --no-ff "$tagname" || \
+			    die "There were merge conflicts."
+			else
+			  git merge --no-ff "$MASTER_BRANCH" || \
+			    die "There were merge conflicts."
+			fi
+		fi
+	else
+		# in case a previous attempt to finish this hotfix branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
+
+			# just merge the release branch into the development branch
+			git merge --no-ff "$BRANCH" || \
+			  die "There were merge conflicts."
+		fi
 	fi
 
 	# delete branch
@@ -309,9 +328,16 @@ cmd_finish() {
 	echo "- Latest objects have been fetched from '$ORIGIN'"
 	echo "- Hotfix branch has been merged into '$MASTER_BRANCH'"
 	if noflag notag; then
-		echo "- The hotfix was tagged '$VERSION_PREFIX$VERSION'"
+		echo "- The hotfix was tagged '$tagname'"
+		if noflag nobackmerge; then
+			echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+		fi
 	fi
-	echo "- Hotfix branch has been back-merged into '$DEVELOP_BRANCH'"
+	if flag nobackmerge; then
+		echo "- Hotfix branch has been back-merged into '$DEVELOP_BRANCH'"
+	else
+        echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+	fi
 	if flag keep; then
 		echo "- Hotfix branch '$BRANCH' is still available"
 	else

--- a/git-flow-release
+++ b/git-flow-release
@@ -45,7 +45,7 @@ PREFIX=$(git config --get gitflow.prefix.release)
 usage() {
 	echo "usage: git flow release [list] [-v]"
 	echo "       git flow release start [-F] <version> [<base>]"
-	echo "       git flow release finish [-Fsumpk] <version>"
+	echo "       git flow release finish [-Fsumpkb] <version>"
 	echo "       git flow release publish <name>"
 	echo "       git flow release track <name>"
 }
@@ -193,7 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
-	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
+	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)" b
 
 	parse_args "$@"
 	require_version_arg

--- a/git-flow-release
+++ b/git-flow-release
@@ -193,7 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
-	DEFINE_boolean backmerge false "back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
+	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
 
 	parse_args "$@"
 	require_version_arg
@@ -246,7 +246,7 @@ cmd_finish() {
 	fi
 
 	# try to merge into develop
-	if flag backmerge; then
+	if noflag nobackmerge; then
 		# in case a previous attempt to finish this release branch has failed,
 		# but the merge into develop was successful, we skip it now
 		if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
@@ -302,18 +302,16 @@ cmd_finish() {
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
-	if noflag backmerge; then
-		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
-	fi
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
-		if flag backmerge; then
+		if noflag nobackmerge; then
 			echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
 		fi
+	fi
+	if flag nobackmerge; then
+		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
 	else
-		if flag backmerge; then
-			echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
-		fi
+        echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
 	fi
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"

--- a/git-flow-release
+++ b/git-flow-release
@@ -193,6 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+	DEFINE_boolean backmerge false "back-merge $MASTER_BRANCH to be a parent of $DEVELOP_BRANCH (using tag if applicable)"
 
 	parse_args "$@"
 	require_version_arg
@@ -245,21 +246,34 @@ cmd_finish() {
 	fi
 
 	# try to merge into develop
-	# in case a previous attempt to finish this release branch has failed,
-	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
-		git checkout "$DEVELOP_BRANCH" || \
-		  die "Could not check out $DEVELOP_BRANCH."
+	if flag backmerge; then
+		# in case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
 
-		# merge the master branch back into develop; this makes the master
-		# branch - and the new tag (if provided) - a parent of the development
-		# branch, which in turn lets you use 'git describe' on either branch
-		if noflag notag; then
-		  git merge --no-ff "$tagname" || \
-		    die "There were merge conflicts."
-		else
-		  git merge --no-ff "$MASTER_BRANCH" || \
-		    die "There were merge conflicts."
+			# merge the master branch back into develop; this makes the master
+			# branch - and the new tag (if provided) - a parent of the development
+			# branch, which in turn lets you use 'git describe' on either branch
+			if noflag notag; then
+			  git merge --no-ff "$tagname" || \
+			    die "There were merge conflicts."
+			else
+			  git merge --no-ff "$MASTER_BRANCH" || \
+			    die "There were merge conflicts."
+			fi
+		fi
+	else
+		# in case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || \
+			  die "Could not check out $DEVELOP_BRANCH."
+
+			# just merge the release branch into the development branch
+			git merge --no-ff "$BRANCH" || \
+			  die "There were merge conflicts."
 		fi
 	fi
 
@@ -288,11 +302,18 @@ cmd_finish() {
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
+	if noflag backmerge; then
+		echo "- Release branch has been merged into '$DEVELOP_BRANCH'"
+	fi
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
-		echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+		if flag backmerge; then
+			echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+		fi
 	else
-		echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		if flag backmerge; then
+			echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		fi
 	fi
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"

--- a/git-flow-release
+++ b/git-flow-release
@@ -247,15 +247,20 @@ cmd_finish() {
 	# try to merge into develop
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
+	if ! git_is_branch_merged_into "$MASTER_BRANCH" "$DEVELOP_BRANCH"; then
 		git checkout "$DEVELOP_BRANCH" || \
 		  die "Could not check out $DEVELOP_BRANCH."
 
-		# TODO: Actually, accounting for 'git describe' pays, so we should
-		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+		# merge the master branch back into develop; this makes the master
+		# branch - and the new tag (if provided) - a parent of the development
+		# branch, which in turn lets you use 'git describe' on either branch
+		if noflag notag; then
+		  git merge --no-ff "$tagname" || \
+		    die "There were merge conflicts."
+		else
+		  git merge --no-ff "$MASTER_BRANCH" || \
+		    die "There were merge conflicts."
+		fi
 	fi
 
 	# delete branch
@@ -285,8 +290,10 @@ cmd_finish() {
 	echo "- Release branch has been merged into '$MASTER_BRANCH'"
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
+		echo "- Tag '$tagname' has been back-merged into '$DEVELOP_BRANCH'"
+	else
+		echo "- Branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
 	fi
-	echo "- Release branch has been back-merged into '$DEVELOP_BRANCH'"
 	if flag keep; then
 		echo "- Release branch '$BRANCH' is still available"
 	else


### PR DESCRIPTION
This replaces pull request #85, which became difficult to maintain due to the fact that I didn't base my pull request off a feature branch (old newb mistake).

This pull request modifies the `release finish` command to back-merge the release branch (or the release tag if it was created) into the development branch as the final step of finishing a release. This makes the tag an ancestor of the development branch, which in turn enables `git describe` to be meaningful on the development branch as well as the release branch.
