### PR TITLE
permit branch name guesses that match a remote branch

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -100,7 +100,8 @@ cmd_default() {
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.master) \
 			             'production' 'main' 'master'; do
-				if git_local_branch_exists "$guess"; then
+				if git_local_branch_exists "$guess" || \
+					git_remote_branch_exists "origin/$guess"; then
 					default_suggestion="$guess"
 					break
 				fi
@@ -153,7 +154,8 @@ cmd_default() {
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.develop) \
 			             'develop' 'int' 'integration' 'master'; do
-				if git_local_branch_exists "$guess"; then
+				if git_local_branch_exists "$guess" || \
+					git_remote_branch_exists "origin/$guess"; then
 					default_suggestion="$guess"
 					break
 				fi


### PR DESCRIPTION
During `flow init`, if the user enters a branch name that does not exist locally, but does exist remotely, it will create a remote tracking branch rather than `die`. This patch will allow guesses to be presented if either a local or remote branch exists.

This is particularly useful when using `git flow init -df` when local branches may not exist (maybe because they were deleted locally, or because one is using a .gitflow variant).

Of course, it is also useful if you have a fresh clone of a flow-enabled repo (with only one local branch) and want to quickly `flow init` it without first tracking branches locally. Without this patch, `master` (or whatever HEAD branch got cloned) will be suggested for both master and develop branches; with this patch, the remote `develop` branch is detected and suggested to the user.
