### PR TITLE
Feature/separate gitflow config directory and file

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -68,8 +68,6 @@ main() {
 
 	# load common functionality
 	. "$GITFLOW_DIR/gitflow-common"
-	# Setup common variables
-	gitflow_setup_common_variables
 
 	# This environmental variable fixes non-POSIX getopt style argument
 	# parsing, effectively breaking git-flow subcommand parsing on several

--- a/git-flow
+++ b/git-flow
@@ -68,6 +68,8 @@ main() {
 
 	# load common functionality
 	. "$GITFLOW_DIR/gitflow-common"
+	# Setup common variables
+	gitflow_setup_common_variables
 
 	# This environmental variable fixes non-POSIX getopt style argument
 	# parsing, effectively breaking git-flow subcommand parsing on several

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -37,6 +37,9 @@
 #
 
 require_git_repo
+# Setup common variables
+gitflow_setup_common_variables
+
 require_gitflow_initialized
 gitflow_load_settings
 PREFIX=$(git config --file $GITFLOW_CONF --get gitflow.prefix.feature)

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -39,7 +39,7 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-PREFIX=$(git config --get gitflow.prefix.feature)
+PREFIX=$(git config --file $GITFLOW_CONF --get gitflow.prefix.feature)
 
 usage() {
 	echo "usage: git flow feature [list] [-v]"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.hotfix)
+VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")
+PREFIX=$(git config --file $GITFLOW_CONF --get gitflow.prefix.hotfix)
 
 usage() {
 	echo "usage: git flow hotfix [list] [-v]"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -37,6 +37,9 @@
 #
 
 require_git_repo
+# Setup common variables
+gitflow_setup_common_variables
+	
 require_gitflow_initialized
 gitflow_load_settings
 VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")

--- a/git-flow-init
+++ b/git-flow-init
@@ -59,6 +59,9 @@ cmd_default() {
 		git_repo_is_headless || require_clean_working_tree
 	fi
 
+	# Setup common variables
+	gitflow_setup_common_variables
+
 	# running git flow init on an already initialized repo is fine
 	if gitflow_is_initialized && ! flag force; then
 		warn "Already initialized for gitflow."

--- a/git-flow-init
+++ b/git-flow-init
@@ -314,6 +314,10 @@ cmd_default() {
 }
 
 cmd_upgrade() {
+	require_git_repo
+	# Setup common variables
+	gitflow_setup_common_variables
+	
 	if gitflow_has_config; then
 		warn "Not upgrading as there already is the config file."
 		exit 0
@@ -330,31 +334,27 @@ cmd_upgrade() {
 	
 	old_setting=$(git config --get gitflow.branch.master)
 	git config --file $GITFLOW_CONF gitflow.branch.master "$old_setting"
-	git config --unset gitflow.branch.master
 	
 	old_setting=$(git config --get gitflow.branch.develop)
 	git config --file $GITFLOW_CONF gitflow.branch.develop "$old_setting"
-	git config --unset gitflow.branch.develop
 	
 	old_setting=$(git config --get gitflow.prefix.feature)
 	git config --file $GITFLOW_CONF gitflow.prefix.feature "$old_setting"
-	git config --unset gitflow.prefix.feature
 	
 	old_setting=$(git config --get gitflow.prefix.release)
 	git config --file $GITFLOW_CONF gitflow.prefix.release "$old_setting"
-	git config --unset gitflow.prefix.release
 	
 	old_setting=$(git config --get gitflow.prefix.hotfix)
 	git config --file $GITFLOW_CONF gitflow.prefix.hotfix "$old_setting"
-	git config --unset gitflow.prefix.hotfix
 	
 	old_setting=$(git config --get gitflow.prefix.support)
 	git config --file $GITFLOW_CONF gitflow.prefix.support "$old_setting"
-	git config --unset gitflow.prefix.support
 	
 	old_setting=$(git config --get gitflow.prefix.versiontag)
 	git config --file $GITFLOW_CONF gitflow.prefix.versiontag "$old_setting"
-	git config --unset gitflow.prefix.versiontag
+	
+	git config --remove-section gitflow.prefix
+	git config --remove-section gitflow.branch
 }
 
 cmd_help() {

--- a/git-flow-init
+++ b/git-flow-init
@@ -66,6 +66,9 @@ cmd_default() {
 		exit 0
 	fi
 
+	# Check if directory exists, if not we create it.
+	require_gitflow_conf_directory
+	
 	local branch_count
 	local answer
 
@@ -305,6 +308,50 @@ cmd_default() {
 
 
 	# TODO: what to do with origin?
+}
+
+cmd_upgrade() {
+	if gitflow_has_config; then
+		warn "Not upgrading as there already is the config file."
+		exit 0
+	fi
+	
+	if ! gitflow_has_prefixes_configured_old_way; then
+			die "fatal: Not a gitflow-enabled repo yet. Please run \"git flow init\". There's no need to upgrade"
+	fi
+	
+	# Check if directory exists, if not we create it.
+	require_gitflow_conf_directory
+
+	local old_setting
+	
+	old_setting=$(git config --get gitflow.branch.master)
+	git config --file $GITFLOW_CONF gitflow.branch.master "$old_setting"
+	git config --unset gitflow.branch.master
+	
+	old_setting=$(git config --get gitflow.branch.develop)
+	git config --file $GITFLOW_CONF gitflow.branch.develop "$old_setting"
+	git config --unset gitflow.branch.develop
+	
+	old_setting=$(git config --get gitflow.prefix.feature)
+	git config --file $GITFLOW_CONF gitflow.prefix.feature "$old_setting"
+	git config --unset gitflow.prefix.feature
+	
+	old_setting=$(git config --get gitflow.prefix.release)
+	git config --file $GITFLOW_CONF gitflow.prefix.release "$old_setting"
+	git config --unset gitflow.prefix.release
+	
+	old_setting=$(git config --get gitflow.prefix.hotfix)
+	git config --file $GITFLOW_CONF gitflow.prefix.hotfix "$old_setting"
+	git config --unset gitflow.prefix.hotfix
+	
+	old_setting=$(git config --get gitflow.prefix.support)
+	git config --file $GITFLOW_CONF gitflow.prefix.support "$old_setting"
+	git config --unset gitflow.prefix.support
+	
+	old_setting=$(git config --get gitflow.prefix.versiontag)
+	git config --file $GITFLOW_CONF gitflow.prefix.versiontag "$old_setting"
+	git config --unset gitflow.prefix.versiontag
 }
 
 cmd_help() {

--- a/git-flow-init
+++ b/git-flow-init
@@ -76,7 +76,7 @@ cmd_default() {
 	# add a master branch if no such branch exists yet
 	local master_branch
 	if gitflow_has_master_configured && ! flag force; then
-		master_branch=$(git config --get gitflow.branch.master)
+		master_branch=$(git config --file $GITFLOW_CONF --get gitflow.branch.master)
 	else
 		# Two cases are distinguished:
 		# 1. A fresh git repo (without any branches)
@@ -90,7 +90,7 @@ cmd_default() {
 		if [ "$branch_count" -eq 0 ]; then
 			echo "No branches exist yet. Base branches must be created now."
 			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.master || echo master)
+			default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.branch.master || echo master)
 		else
 			echo
 			echo "Which branch should be used for bringing forth production releases?"
@@ -98,7 +98,7 @@ cmd_default() {
 
 			should_check_existence=YES
 			default_suggestion=
-			for guess in $(git config --get gitflow.branch.master) \
+			for guess in $(git config --file $GITFLOW_CONF --get gitflow.branch.master) \
 			             'production' 'main' 'master'; do
 				if git_local_branch_exists "$guess"; then
 					default_suggestion="$guess"
@@ -128,7 +128,7 @@ cmd_default() {
 		fi
 
 		# store the name of the master branch
-		git config gitflow.branch.master "$master_branch"
+		git config --file $GITFLOW_CONF --file $GITFLOW_CONF gitflow.branch.master "$master_branch"
 	fi
 
 	# add a develop branch if no such branch exists yet
@@ -143,7 +143,7 @@ cmd_default() {
 		branch_count=$(git_local_branches | grep -v "^${master_branch}\$" | wc -l)
 		if [ "$branch_count" -eq 0 ]; then
 			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
+			default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.branch.develop || echo develop)
 		else
 			echo
 			echo "Which branch should be used for integration of the \"next release\"?"
@@ -151,7 +151,7 @@ cmd_default() {
 
 			should_check_existence=YES
 			default_suggestion=
-			for guess in $(git config --get gitflow.branch.develop) \
+			for guess in $(git config --file $GITFLOW_CONF --get gitflow.branch.develop) \
 			             'develop' 'int' 'integration' 'master'; do
 				if git_local_branch_exists "$guess"; then
 					default_suggestion="$guess"
@@ -179,7 +179,7 @@ cmd_default() {
 		fi
 
 		# store the name of the develop branch
-		git config gitflow.branch.develop "$develop_branch"
+		git config --file $GITFLOW_CONF gitflow.branch.develop "$develop_branch"
 	fi
 
 	# Creation of HEAD
@@ -224,11 +224,11 @@ cmd_default() {
 
 	# finally, ask the user for naming conventions (branch and tag prefixes)
 	if flag force || \
-	   ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.support >/dev/null 2>&1 || 
-	   ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1; then
+	   ! git config --file $GITFLOW_CONF --get gitflow.prefix.feature >/dev/null 2>&1 || 
+	   ! git config --file $GITFLOW_CONF --get gitflow.prefix.release >/dev/null 2>&1 || 
+	   ! git config --file $GITFLOW_CONF --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
+	   ! git config --file $GITFLOW_CONF --get gitflow.prefix.support >/dev/null 2>&1 || 
+	   ! git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag >/dev/null 2>&1; then
 		echo
 		echo "How to name your supporting branch prefixes?"
 	fi
@@ -236,8 +236,8 @@ cmd_default() {
 	local prefix
 
 	# Feature branches
-	if ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature/)
+	if ! git config --file $GITFLOW_CONF --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.prefix.feature || echo feature/)
 		printf "Feature branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -245,12 +245,12 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.feature "$prefix"
+		git config --file $GITFLOW_CONF gitflow.prefix.feature "$prefix"
 	fi
 
 	# Release branches
 	if ! git config --get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.release || echo release/)
+		default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.prefix.release || echo release/)
 		printf "Release branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -258,13 +258,13 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.release "$prefix"
+		git config --file $GITFLOW_CONF gitflow.prefix.release "$prefix"
 	fi
 
 
 	# Hotfix branches
-	if ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix/)
+	if ! git config --file $GITFLOW_CONF --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.prefix.hotfix || echo hotfix/)
 		printf "Hotfix branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -272,13 +272,13 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.hotfix "$prefix"
+		git config --file $GITFLOW_CONF gitflow.prefix.hotfix "$prefix"
 	fi
 
 
 	# Support branches
-	if ! git config --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.support || echo support/)
+	if ! git config --file $GITFLOW_CONF --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.prefix.support || echo support/)
 		printf "Support branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -286,13 +286,13 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.support "$prefix"
+		git config --file $GITFLOW_CONF gitflow.prefix.support "$prefix"
 	fi
 
 
 	# Version tag prefix
-	if ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "")
+	if ! git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag || echo "")
 		printf "Version tag prefix? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -300,7 +300,7 @@ cmd_default() {
 			printf "\n"
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
-		git config gitflow.prefix.versiontag "$prefix"
+		git config --file $GITFLOW_CONF gitflow.prefix.versiontag "$prefix"
 	fi
 
 

--- a/git-flow-init
+++ b/git-flow-init
@@ -131,7 +131,7 @@ cmd_default() {
 		fi
 
 		# store the name of the master branch
-		git config --file $GITFLOW_CONF --file $GITFLOW_CONF gitflow.branch.master "$master_branch"
+		git config --file $GITFLOW_CONF gitflow.branch.master "$master_branch"
 	fi
 
 	# add a develop branch if no such branch exists yet

--- a/git-flow-release
+++ b/git-flow-release
@@ -37,6 +37,9 @@
 #
 
 require_git_repo
+# Setup common variables
+gitflow_setup_common_variables
+
 require_gitflow_initialized
 gitflow_load_settings
 VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")

--- a/git-flow-release
+++ b/git-flow-release
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.release)
+VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")
+PREFIX=$(git config --file $GITFLOW_CONF --get gitflow.prefix.release)
 
 usage() {
 	echo "usage: git flow release [list] [-v]"

--- a/git-flow-support
+++ b/git-flow-support
@@ -37,6 +37,9 @@
 #
 
 require_git_repo
+# Setup common variables
+gitflow_setup_common_variables
+
 require_gitflow_initialized
 gitflow_load_settings
 VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")

--- a/git-flow-support
+++ b/git-flow-support
@@ -39,8 +39,8 @@
 require_git_repo
 require_gitflow_initialized
 gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.support)
+VERSION_PREFIX=$(eval "echo `git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag`")
+PREFIX=$(git config --file $GITFLOW_CONF --get gitflow.prefix.support)
 
 warn "note: The support subcommand is still very EXPERIMENTAL!"
 warn "note: DO NOT use it in a production situation."

--- a/gitflow-common
+++ b/gitflow-common
@@ -156,6 +156,17 @@ git_is_branch_merged_into() {
 # gitflow specific common functionality
 #
 
+# Setup common variables
+gitflow_setup_common_variables() {
+	local dot_gitflow_dir=".gitflow"
+	export GITFLOW_CONF="$dot_gitflow_dir/conf"
+}
+
+# Check if the repo has the new configuration layout
+gitflow_has_config() {
+	[ -f $GITFLOW_CONF ]
+}
+
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
 	local master=$(git config --get gitflow.branch.master)
@@ -175,7 +186,22 @@ gitflow_has_prefixes_configured() {
 	git config --get gitflow.prefix.versiontag >/dev/null 2>&1
 }
 
+gitflow_has_prefixes_configured_old_way() {
+	git config --get gitflow.prefix.feature >/dev/null 2>&1     && \
+	git config --get gitflow.prefix.release >/dev/null 2>&1     && \
+	git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
+	git config --get gitflow.prefix.support >/dev/null 2>&1     && \
+	git config --get gitflow.prefix.versiontag >/dev/null 2>&1
+
+}
+
 gitflow_is_initialized() {
+if ! gitflow_has_config; then
+			if gitflow_has_prefixes_configured_old_way; then
+				die "Fatal: gitflow upgrade needed. Please run \"git flow init\" first."
+			fi
+			return 1;
+	fi
 	gitflow_has_master_configured                    && \
 	gitflow_has_develop_configured                   && \
 	[ "$(git config --get gitflow.branch.master)" !=    \
@@ -183,12 +209,14 @@ gitflow_is_initialized() {
 	gitflow_has_prefixes_configured
 }
 
+
 # loading settings that can be overridden using git config
 gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
 	export ORIGIN=$(git config --get gitflow.origin || echo origin)
+	
 }
 
 #

--- a/gitflow-common
+++ b/gitflow-common
@@ -196,11 +196,11 @@ gitflow_has_prefixes_configured_old_way() {
 }
 
 gitflow_is_initialized() {
-if ! gitflow_has_config; then
-			if gitflow_has_prefixes_configured_old_way; then
-				die "Fatal: gitflow upgrade needed. Please run \"git flow init\" first."
-			fi
-			return 1;
+	if ! gitflow_has_config; then
+		if gitflow_has_prefixes_configured_old_way; then
+			die "Fatal: gitflow upgrade needed. Please run \"git flow init\" first."
+		fi
+		return 1;
 	fi
 	gitflow_has_master_configured                    && \
 	gitflow_has_develop_configured                   && \

--- a/gitflow-common
+++ b/gitflow-common
@@ -169,21 +169,21 @@ gitflow_has_config() {
 
 # check if this repo has been inited for gitflow
 gitflow_has_master_configured() {
-	local master=$(git config --get gitflow.branch.master)
+	local master=$(git config --file $GITFLOW_CONF --get gitflow.branch.master)
 	[ "$master" != "" ] && git_local_branch_exists "$master"
 }
 
 gitflow_has_develop_configured() {
-	local develop=$(git config --get gitflow.branch.develop)
+	local develop=$(git config --file $GITFLOW_CONF --get gitflow.branch.develop)
 	[ "$develop" != "" ] && git_local_branch_exists "$develop"
 }
 
 gitflow_has_prefixes_configured() {
-	git config --get gitflow.prefix.feature >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.release >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
-	git config --get gitflow.prefix.support >/dev/null 2>&1     && \
-	git config --get gitflow.prefix.versiontag >/dev/null 2>&1
+	git config --file $GITFLOW_CONF --get gitflow.prefix.feature >/dev/null 2>&1     && \
+	git config --file $GITFLOW_CONF --get gitflow.prefix.release >/dev/null 2>&1     && \
+	git config --file $GITFLOW_CONF --get gitflow.prefix.hotfix >/dev/null 2>&1      && \
+	git config --file $GITFLOW_CONF --get gitflow.prefix.support >/dev/null 2>&1     && \
+	git config --file $GITFLOW_CONF --get gitflow.prefix.versiontag >/dev/null 2>&1
 }
 
 gitflow_has_prefixes_configured_old_way() {
@@ -204,8 +204,8 @@ if ! gitflow_has_config; then
 	fi
 	gitflow_has_master_configured                    && \
 	gitflow_has_develop_configured                   && \
-	[ "$(git config --get gitflow.branch.master)" !=    \
-	  "$(git config --get gitflow.branch.develop)" ] && \
+	[ "$(git config --file $GITFLOW_CONF --get gitflow.branch.master)" !=    \
+	  "$(git config --file $GITFLOW_CONF --get gitflow.branch.develop)" ] && \
 	gitflow_has_prefixes_configured
 }
 
@@ -213,9 +213,9 @@ if ! gitflow_has_config; then
 # loading settings that can be overridden using git config
 gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
-	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
-	export ORIGIN=$(git config --get gitflow.origin || echo origin)
+	export MASTER_BRANCH=$(git config --file $GITFLOW_CONF --get gitflow.branch.master)
+	export DEVELOP_BRANCH=$(git config --file $GITFLOW_CONF --get gitflow.branch.develop)
+	export ORIGIN=$(git config --file $GITFLOW_CONF --get gitflow.origin || echo origin)
 	
 }
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -158,8 +158,8 @@ git_is_branch_merged_into() {
 
 # Setup common variables
 gitflow_setup_common_variables() {
-	local dot_gitflow_dir=".gitflow"
-	export GITFLOW_CONF="$dot_gitflow_dir/conf"
+	export DOT_GITFLOW_DIR=$(git rev-parse --show-toplevel)"/.gitflow"
+	export GITFLOW_CONF="$DOT_GITFLOW_DIR/conf"
 }
 
 # Check if the repo has the new configuration layout
@@ -198,7 +198,7 @@ gitflow_has_prefixes_configured_old_way() {
 gitflow_is_initialized() {
 	if ! gitflow_has_config; then
 		if gitflow_has_prefixes_configured_old_way; then
-			die "Fatal: gitflow upgrade needed. Please run \"git flow init\" first."
+			die "Fatal: gitflow upgrade needed. Please run \"git flow init upgrade\" first."
 		fi
 		return 1;
 	fi
@@ -343,4 +343,10 @@ require_branches_equal() {
 			die "Branches need merging first."
 		fi
 	fi
+}
+
+require_gitflow_conf_directory() {
+	 if [ ! -d  $DOT_GITFLOW_DIR ]; then
+		 mkdir $DOT_GITFLOW_DIR
+	 fi
 }


### PR DESCRIPTION
This moves the configuration of gitflow into a separate directory and file. This would be part of a next feature, adding hooks, which also would be stored in the same gitflow directory.

To keep in line with git's structure I used the following naming convention:
- Directory name: .gitflow
- Configuration file: conf

More info can be found in issue #183
