### PR TITLE
Feature/implement version filter

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -157,6 +157,10 @@ cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
 	BASE=${2:-$MASTER_BRANCH}
+	# Run filter on the version
+	VERSION=`run_filter_hook hotfix-start-version $VERSION`
+	# As VERSION might have changed reset BRANCH with new VERSION
+	BRANCH=$PREFIX$VERSION
 	require_version_arg
 	require_base_is_on_master
 	require_no_existing_hotfix_branches

--- a/git-flow-release
+++ b/git-flow-release
@@ -153,6 +153,10 @@ cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
 	BASE=${2:-$DEVELOP_BRANCH}
+	# Run filter on the version
+	VERSION=`run_filter_hook release-start-version $VERSION`
+	# As VERSION might have changed reset BRANCH with new VERSION
+	BRANCH=$PREFIX$VERSION
 	require_version_arg
 	require_base_is_on_develop
 	require_no_existing_release_branches

--- a/gitflow-common
+++ b/gitflow-common
@@ -186,6 +186,7 @@ gitflow_is_initialized() {
 # loading settings that can be overridden using git config
 gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+	export HOOKS_DIR="$DOT_GIT_DIR"/hooks
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
 	export ORIGIN=$(git config --get gitflow.origin || echo origin)
@@ -314,5 +315,26 @@ require_branches_equal() {
 		else
 			die "Branches need merging first."
 		fi
+	fi
+}
+
+#
+# run_filter_hook
+#
+# Looks for a Git hook script called as defined by the first variable
+#
+#     filter-flow-command
+#
+# If such a hook script exists and is executable, it is called with the given
+# positional arguments.
+#
+run_filter_hook() {
+	local command=$1
+	shift
+	local scriptfile="${HOOKS_DIR}/filter-flow-${command}"
+	if [ -x $scriptfile ]; then
+		echo `$scriptfile "$@"`
+	else
+		echo "$@"
 	fi
 }

--- a/hooks/filter-flow-hotfix-start-version
+++ b/hooks/filter-flow-hotfix-start-version
@@ -5,6 +5,9 @@
 # Positional arguments:
 # $1    Version
 #
+# Return VERSION - When VERSION is returned empty gitflow 
+#	will stop as the version is necessary
+#
 VERSION=$1
 
 # Implement your script here.

--- a/hooks/filter-flow-hotfix-start-version
+++ b/hooks/filter-flow-hotfix-start-version
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Runs during git flow hotfix start
+#
+# Positional arguments:
+# $1    Version
+#
+VERSION=$1
+
+# Implement your script here.
+
+# Return the VERSION
+echo ${VERSION}
+exit 0

--- a/hooks/filter-flow-release-start-version
+++ b/hooks/filter-flow-release-start-version
@@ -5,6 +5,9 @@
 # Positional arguments:
 # $1    Version
 #
+# Return VERSION - When VERSION is returned empty gitflow 
+#	will stop as the version is necessary
+#
 VERSION=$1
 
 # Implement your script here.

--- a/hooks/filter-flow-release-start-version
+++ b/hooks/filter-flow-release-start-version
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Runs during git flow release start
+#
+# Positional arguments:
+# $1    Version
+#
+VERSION=$1
+
+# Implement your script here.
+
+# Return the VERSION
+echo ${VERSION}
+exit 0


### PR DESCRIPTION
Issue #129 asks to "add version number auto-increment support". Instead of having users to adhere to a given scheme I wrote a filter hook for the following commands:
git flow release start
git flow hotfix start
## Explanation of the filter implementation.
- A universal function is created called run_filter_hook
- Naming conventions of the filter scripts `filter-flow-{command}` For example `filter-flow-hotfix-start-version`
- The filter hook function is called with the 1st parameter being the {command} and the 2nd parameter being the value that needs to be passed to the script.
- To keep in line with the implementation of the hooks implementation, I used the HOOKS_DIR setup as done in pull request #185
- If the called filter script doesn't exist or is not executable, the returned value is the same as the received one.
## Filter names used

filter-flow-hotfix-start-version
filter-flow-release-start-version
