### PR TITLE
fix usage of shFlags on FreeBSD

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -37,6 +37,9 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
+# set this to workaround expr problems in shFlags on freebsd
+if uname -s | egrep -iq 'bsd'; then export EXPR_COMPAT=1; fi
+
 # enable debug mode
 if [ "$DEBUG" = "yes" ]; then
 	set -x


### PR DESCRIPTION
In order to make shFlags work appropriately on FreeBSD, one must set the `EXPR_COMPAT` environment variable to `1`.

This patch sets the environment variable appropriately if running inside bsd. This makes things like `git flow init -d` work appropriately in that environment.
