### PR TITLE
Installer using the Git read-only url instead of https.

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="git://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
When attempting to use the GNU/Linux installation instructions (installation shell script) I received the following error:

```
$ wget --no-check-certificate -q -O - https://github.com/nvie/gitflow/raw/develop/contrib/gitflow-installer.sh | sudo bash
### gitflow no-make installer ###
Installing git-flow to /usr/local/bin
Cloning repo from GitHub to gitflow
Cloning into 'gitflow'...
fatal: Unable to find remote helper for 'http'
Updating submodules
bash: line 64: cd: gitflow: No such file or directory
fatal: Not a git repository (or any parent up to mount parent )
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: Not a git repository (or any parent up to mount parent )
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
install: cannot stat `gitflow/git-flow': No such file or directory
install: cannot stat `gitflow/git-flow-init': No such file or directory
install: cannot stat `gitflow/git-flow-feature': No such file or directory
install: cannot stat `gitflow/git-flow-hotfix': No such file or directory
install: cannot stat `gitflow/git-flow-release': No such file or directory
install: cannot stat `gitflow/git-flow-support': No such file or directory
install: cannot stat `gitflow/git-flow-version': No such file or directory
install: cannot stat `gitflow/gitflow-common': No such file or directory
install: cannot stat `gitflow/gitflow-shFlags': No such file or directory
```

Using the read-only Git URL instead resolved this issue for me and presumably should work for everyone unlike the http link.
