### PR TITLE
Updating the escape characters to fix + in the branch name

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -45,7 +45,7 @@ warn() { echo "$@" >&2; }
 die() { warn "$@"; exit 1; }
 
 escape() {
-	echo "$1" | sed 's/\([\.\+\$\*]\)/\\\1/g'
+	echo "$1" | sed 's/\([\.\$\*]\)/\\\1/g'
 }
 
 # set logic


### PR DESCRIPTION
Since git allows for it the escape should not escape it since it then won't match the branch names correctly.

See issue #148
