### PR TITLE
Added options (-m and -a) on feature finish action that allow to change default merge message.

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -232,6 +232,8 @@ cmd_finish() {
 	DEFINE_boolean rebase false "rebase instead of merge" r
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
+	DEFINE_string  message "" "custom merge message" m
+	DEFINE_string  append_message ""  "append a message to default merge message" a
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -308,12 +310,37 @@ cmd_finish() {
 	fi
 
 	# merge into BASE
-	git checkout "$DEVELOP_BRANCH"
-	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
-		git merge --ff "$BRANCH"
+	local append_message=""
+	# get and evaluate feature finish append message, since it can contain custom subcommands that use $BRANCH variable
+	if [ "$FLAGS_append_message" != "" ]; then
+		eval "append_message=\"$FLAGS_append_message\""
 	else
-		git merge --no-ff "$BRANCH"
+		# no command line message defined, trying default from config
+		if [ "$(git config gitflow.feature.finish.append)" != "" ]; then
+			eval "append_message=\"$(git config gitflow.feature.finish.append) \""
+		fi
 	fi
+
+	local opts=""
+	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
+		STRATEGY="--ff"
+		# on fast forward merge we use git commit --amend since there's only 1 commit
+		if [ "$append_message" != "" ]; then
+			git checkout "$BRANCH"
+			git commit --amend -m "$(echo "$(git log -n 1 --pretty=%s)\n$append_message")"
+		fi
+	else
+		if [ "$FLAGS_message" != "" ]; then
+			opts="-m '$FLAGS_message'"
+				else
+			if [ "$append_message" != "" ]; then
+				opts=$(echo "-m 'Merge branch $BRANCH into $DEVELOP_BRANCH.\n$append_message'")
+			fi
+		fi
+		STRATEGY="--no-ff"
+	fi
+	git checkout "$DEVELOP_BRANCH"
+	eval git merge "$opts" "$STRATEGY" "$BRANCH"
 
 	if [ $? -ne 0 ]; then
 		# oops.. we have a merge conflict!


### PR DESCRIPTION
Those are:
- custom merge message option (-m)
- custom appended message to a default merge message (-a)
- default addition to -a option via git config option gitflow.feature.finish.append.

Why is this needed?
Some (maybe many) bugtrackers allow closing issues by mentioning them in the commit messages, like `#VM-123 fixed`. That's cool and we like do that. But in our company before closing task the code (a branch) should pass code review. So it would be convenient to automatically add some text into a merge message when branch is merged into mainstream (develop), so task can be closed.

How to test: 
Create test repo with the following: 

```
mkdir /tmp/repo; cd /tmp/repo; git flow init -d; git config gitflow.feature.finish.append '#VM-$(echo $BRANCH | grep -oP "\d+") fixed'; touch README; git add . ; git commit -m "initial commit"
```

As you may noted, config option will be `eval`uated on run, so user basically can use some template logic based on branch-name, that's very convenient.

Test fast-forward merges with following:

```
git flow feature start vm-1234-test; echo commit >> README ; git commit -am 'commit'; git flow feature finish; git log --shortstat -n 1
```

You should see git flow output and something like that in the end:

```
commit 3d9039fb58bf05537ca9de00052d4d20570783a2
Author: Shein Alexey <confik@gmail.com>
Date:   Wed Mar 14 02:55:36 2012 +0500

    commit
    #VM-1234 fixed

 1 files changed, 1 insertions(+), 0 deletions(-)
```

Note #VM-1234 fixed, that was added by my patch.

Test recursive merges with following: 

```
git flow feature start vm-1234-test; echo commit >> README ; git commit -am 'commit'; echo commit >> README ; git commit -am 'commit'; echo commit >> README ; git commit -am 'commit'; git flow feature finish; git log --shortstat  -n 1
```

You should see git flow output and something like that:

```
commit eb527929d89fc1f0b137664c8077f05f5a74dd72
Merge: 3d9039f 319cb16
Author: Shein Alexey <confik@gmail.com>
Date:   Wed Mar 14 02:57:25 2012 +0500

    Merge branch feature/vm-1234-test into develop.
    #VM-1234 fixed

commit 319cb16e5f4a2d4e15c3b8283a4a6c0846760a77
```

You can also specify custom merge message via -m option and append message via -a option if you need some more flexibility.
