### PR TITLE
make the installer for msysgit search in ~/bin as well

### DIFF
--- a/contrib/msysgit-install.cmd
+++ b/contrib/msysgit-install.cmd
@@ -63,6 +63,7 @@ goto :End
 :ChkGetopt
 :: %1 is getopt.exe
 if exist "%GIT_HOME%\bin\%1" goto :EOF
+if exist "%USERPROFILE%\bin\%1" goto :EOF
 if exist "%~f$PATH:1" goto :EOF
 echo %GIT_HOME%\bin\%1 not found.>&2
 echo You have to install this file manually. See the GitFlow README.


### PR DESCRIPTION
This allows the user to place getopt.exe in ~/bin which doesn't require administrative rights to write to.
