### PR TITLE
Feature and Release squashing options #14

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -44,7 +44,7 @@ PREFIX=$(git config --get gitflow.prefix.feature)
 usage() {
 	echo "usage: git flow feature [list] [-v]"
 	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFkD] [<name|nameprefix>]"
+	echo "       git flow feature finish [-rFkDS] [<name|nameprefix>]"
 	echo "       git flow feature publish <name>"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
@@ -232,6 +232,7 @@ cmd_finish() {
 	DEFINE_boolean rebase false "rebase instead of merge" r
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
+    DEFINE_boolean squash false "squash feature during merge" S
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -312,7 +313,13 @@ cmd_finish() {
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		git merge --ff "$BRANCH"
 	else
-		git merge --no-ff "$BRANCH"
+        if noflag squash; then
+		    git merge --no-ff "$BRANCH"
+        else
+            git merge --squash "$BRANCH"
+            git commit
+            git merge "$BRANCH"
+        fi
 	fi
 
 	if [ $? -ne 0 ]; then
@@ -353,7 +360,7 @@ helper_finish_cleanup() {
 			git branch -d "$BRANCH"
 		fi
 	fi
-
+t 
 	echo
 	echo "Summary of actions:"
 	echo "- The feature branch '$BRANCH' was merged into '$DEVELOP_BRANCH'"

--- a/git-flow-release
+++ b/git-flow-release
@@ -45,7 +45,7 @@ PREFIX=$(git config --get gitflow.prefix.release)
 usage() {
 	echo "usage: git flow release [list] [-v]"
 	echo "       git flow release start [-F] <version> [<base>]"
-	echo "       git flow release finish [-Fsumpk] <version>"
+	echo "       git flow release finish [-FsumpkS] <version>"
 	echo "       git flow release publish <name>"
 	echo "       git flow release track <name>"
 }
@@ -193,6 +193,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+    DEFINE_boolean squash false "squash release during merge" S
 
 	parse_args "$@"
 	require_version_arg
@@ -224,9 +225,15 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+        if noflag squash; then
+		    git merge --no-ff "$BRANCH" || \
+		        die "There were merge conflicts."
+		        # TODO: What do we do now?
+        else
+            git merge --squash "$BRANCH" || \
+                die "There were merge conflicts."
+            git commit
+        fi
 	fi
 
 	if noflag notag; then
@@ -253,9 +260,16 @@ cmd_finish() {
 
 		# TODO: Actually, accounting for 'git describe' pays, so we should
 		# ideally git merge --no-ff $tagname here, instead!
-		git merge --no-ff "$BRANCH" || \
-		  die "There were merge conflicts."
-		  # TODO: What do we do now?
+        if noflag squash; then
+		    git merge --no-ff "$BRANCH" || \
+		        die "There were merge conflicts."
+		        # TODO: What do we do now?
+        else
+		    git merge --squash "$BRANCH" || \
+		        die "There were merge conflicts."
+		        # TODO: What do we do now?
+            git commit
+        fi
 	fi
 
 	# delete branch


### PR DESCRIPTION
This allows a -S option to both feature and releasing finishing actions so that users can squash commits into one large one.  Some users like to develop this way an Issue #14 has several up votes for the feature.
