### PR TITLE
Added 'init()' function to git-flow-{feature,release,hotfix,support}

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -109,7 +109,10 @@ main() {
 	fi
 
 	# run the specified action
-	cmd_$SUBACTION "$@"
+  if [ $SUBACTION != "help" ]; then
+    init
+  fi
+  cmd_$SUBACTION "$@"
 }
 
 main "$@"

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -36,10 +36,12 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-require_git_repo
-require_gitflow_initialized
-gitflow_load_settings
-PREFIX=$(git config --get gitflow.prefix.feature)
+init() {
+  require_git_repo
+  require_gitflow_initialized
+  gitflow_load_settings
+  PREFIX=$(git config --get gitflow.prefix.feature)
+}
 
 usage() {
 	echo "usage: git flow feature [list] [-v]"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -36,11 +36,13 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-require_git_repo
-require_gitflow_initialized
-gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.hotfix)
+init() {
+  require_git_repo
+  require_gitflow_initialized
+  gitflow_load_settings
+  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  PREFIX=$(git config --get gitflow.prefix.hotfix)
+}
 
 usage() {
 	echo "usage: git flow hotfix [list] [-v]"

--- a/git-flow-release
+++ b/git-flow-release
@@ -36,11 +36,13 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-require_git_repo
-require_gitflow_initialized
-gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.release)
+init() {
+  require_git_repo
+  require_gitflow_initialized
+  gitflow_load_settings
+  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  PREFIX=$(git config --get gitflow.prefix.release)
+}
 
 usage() {
 	echo "usage: git flow release [list] [-v]"

--- a/git-flow-support
+++ b/git-flow-support
@@ -36,11 +36,13 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-require_git_repo
-require_gitflow_initialized
-gitflow_load_settings
-VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-PREFIX=$(git config --get gitflow.prefix.support)
+init() {
+  require_git_repo
+  require_gitflow_initialized
+  gitflow_load_settings
+  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  PREFIX=$(git config --get gitflow.prefix.support)
+}
 
 warn "note: The support subcommand is still very EXPERIMENTAL!"
 warn "note: DO NOT use it in a production situation."


### PR DESCRIPTION
...which gets called if subargument is not "help"

this fixes the relatively minor issue 204: https://github.com/nvie/gitflow/issues/204: 'git flow subcommand help gives "Not a gitflow-enabled repo yet"'
