### PR TITLE
Fix init -d behaviour when master branch exists, and 1+ other branches exist, but develop does not

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -153,11 +153,17 @@ cmd_default() {
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.develop) \
 			             'develop' 'int' 'integration' 'master'; do
-				if git_local_branch_exists "$guess"; then
+				if git_local_branch_exists "$guess" && [ "$guess" != "$master_branch" ]; then
 					default_suggestion="$guess"
 					break
 				fi
 			done
+			
+			if [ -z $default_suggestion ]; then
+				should_check_existence=NO
+				default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
+			fi
+			
 		fi
 
 		printf "Branch name for \"next release\" development: [$default_suggestion] "


### PR DESCRIPTION
Take the case of a non gitflow repo with an existing 'master' branch, and one or more other branches, but NO 'develop' branch (or 'int' or 'integration').

If you execute 'git flow init -d', or simply 'git flow init' and try to accept the defaults, git flow tries to use 'master' for both the production and the integration branch, which then fails later on.

The issue is around line 154 where if there are branches other than 'master', init tries to find one of 'develop' 'int' 'integration' 'master' to re-use. The first 3 fail, but master succeeds. unfortunately this has already been picked for the production branch.

This change checks for the clash in this case and instead behaves the same as if no other branches were found, defaulting to 'develop' instead (which we know must not exist). This allows the default init behaviour to work in this very common scenario with existing repositories.
