### PR TITLE
Support reading the tag message from a file in release/hotfix finish

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -221,6 +221,7 @@ cmd_finish() {
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
+	DEFINE_string messagefile "" "use the contents of the given file as tag message" f
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
@@ -269,6 +270,7 @@ cmd_finish() {
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
 			eval git tag $opts "$VERSION_PREFIX$VERSION" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi

--- a/git-flow-init
+++ b/git-flow-init
@@ -153,11 +153,17 @@ cmd_default() {
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.develop) \
 			             'develop' 'int' 'integration' 'master'; do
-				if git_local_branch_exists "$guess"; then
+				if git_local_branch_exists "$guess" && [ "$guess" != "$master_branch" ]; then
 					default_suggestion="$guess"
 					break
 				fi
 			done
+			
+			if [ -z $default_suggestion ]; then
+				should_check_existence=NO
+				default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
+			fi
+			
 		fi
 
 		printf "Branch name for \"next release\" development: [$default_suggestion] "

--- a/git-flow-release
+++ b/git-flow-release
@@ -190,6 +190,7 @@ cmd_finish() {
 	DEFINE_boolean sign false "sign the release tag cryptographically" s
 	DEFINE_string signingkey "" "use the given GPG-key for the digital signature (implies -s)" u
 	DEFINE_string message "" "use the given tag message" m
+	DEFINE_string messagefile "" "use the contents of the given file as a tag message" f
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
@@ -239,6 +240,7 @@ cmd_finish() {
 			flag sign && opts="$opts -s"
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
+			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
 			eval git tag $opts "$tagname" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi


### PR DESCRIPTION
This option ('-f' because '-F' was already taken) maps to the 'tag -F' option, and avoids the
problem with issue #98 (https://github.com/nvie/gitflow/issues/98) on Mac
