### PR TITLE
Prevent error message on git flow init

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -109,7 +109,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ]; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
As explained by Peter van der Does, the init command does not have the
init function, nor does it need one.

The error was "line 113: init: command not found"
