### PR TITLE
Prevent error message on flow version command

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -109,7 +109,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
The version subcommand also lacks an init function. This defends against it. I've checked that all the other subcommands have the init call, so they won't make an error message.
