### PR TITLE
Fix squashing feature branch

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -320,7 +320,6 @@ cmd_finish() {
 		else
 			git merge --squash "$BRANCH"
 			git commit
-			git merge "$BRANCH"
 		fi
 	fi
 


### PR DESCRIPTION
If `git flow feature finish` is called with the squash option, the feature branch is merged 2 time.
