### PR TITLE
Allow fast forward style merges.

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -46,7 +46,7 @@ init() {
 usage() {
 	echo "usage: git flow feature [list] [-v]"
 	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFkDS] [<name|nameprefix>]"
+	echo "       git flow feature finish [-rFkDSN] [<name|nameprefix>]"
 	echo "       git flow feature publish <name>"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
@@ -235,6 +235,8 @@ cmd_finish() {
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
 	DEFINE_boolean squash false "squash feature during merge" S
+	DEFINE_boolean nomerge false "use fast-forward rather then a merge commit" N
+
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -310,13 +312,20 @@ cmd_finish() {
 		fi
 	fi
 
+    # by default merge commit otherwise fast-forward instead
+    if noflag nomerge; then
+        MERGE_OPTION='--no-ff'
+    else
+        MERGE_OPTION='--ff'
+    fi
+
 	# merge into BASE
 	git checkout "$DEVELOP_BRANCH"
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		git merge --ff "$BRANCH"
 	else
 		if noflag squash; then
-		    git merge --no-ff "$BRANCH"
+		    git merge "$MERGE_OPTION" "$BRANCH"
 		else
 			git merge --squash "$BRANCH"
 			git commit

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -248,6 +248,7 @@ cmd_finish() {
 	DEFINE_boolean push false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
+	DEFINE_boolean nomerge false "use fast-forward rather then a merge commit" N
 	parse_args "$@"
 	require_version_arg
 
@@ -272,13 +273,20 @@ cmd_finish() {
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
+    # by default merge commit otherwise fast-forward instead
+    if noflag nomerge; then
+        MERGE_OPTION='--no-ff'
+    else
+        MERGE_OPTION='--ff'
+    fi
+
 	# try to merge into master
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
+		git merge "$MERGE_OPTION" "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -197,6 +197,7 @@ cmd_finish() {
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean notag false "don't tag this release" n
 	DEFINE_boolean squash false "squash release during merge" S
+	DEFINE_boolean nomerge false "use fast-forward rather then a merge commit" N
 
 	parse_args "$@"
 	require_version_arg
@@ -222,6 +223,13 @@ cmd_finish() {
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
+    # by default merge commit otherwise fast-forward instead
+    if noflag nomerge; then
+        MERGE_OPTION='--no-ff'
+    else
+        MERGE_OPTION='--ff'
+    fi
+
 	# try to merge into master
 	# in case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
@@ -229,7 +237,7 @@ cmd_finish() {
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
 		if noflag squash; then
-			git merge --no-ff "$BRANCH" || \
+			git merge "$MERGE_OPTION" "$BRANCH" || \
 				die "There were merge conflicts."
 				# TODO: What do we do now?
 		else


### PR DESCRIPTION
Merge commits are great. But some projects want and/or require linear
histories. git flow is still a great tool for them, they just need to
fast forward instead of merge commit.

This patch allows the default behavior of merge commits to remain while
supporting projects that need the other style.
