### PR TITLE
Prevent error message on git flow version

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -109,7 +109,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
Seems the same problem as #235

`The error was "line 113: init: command not found"`

My gut feeling is what `git flow version` command does not require to invoke flow-initialization logics.
