### PR TITLE
This patch tries to solve the following problem:

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -220,13 +220,13 @@ cmd_start() {
 	fi
 
 	# get remote, if differnt
-	local branch_remote=`gitflow_get_remote $BRANCH`
+	branch_remote=`gitflow_get_remote $BRANCH`
 
 	echo
 	echo "Summary of actions:"
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
 	echo "- You are now on branch '$BRANCH'"
-	[ ! -z $branch_remote ] && echo "- Changes will be pushed to $branch_remote"
+	[ ! -z "$branch_remote" ] && echo "- Changes will be pushed to $branch_remote"
 	echo ""
 	echo "Now, start committing on your feature. When done, use:"
 	echo ""

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -53,6 +53,7 @@ usage() {
 	echo "       git flow feature rebase [-i] [<name|nameprefix>]"
 	echo "       git flow feature checkout [<name|nameprefix>]"
 	echo "       git flow feature pull [-r] <remote> [<name>]"
+	echo "       git flow feature remoteset <remote>[:<target-branch>]"
 }
 
 cmd_default() {
@@ -218,10 +219,14 @@ cmd_start() {
 		die "Could not create feature branch '$BRANCH'"
 	fi
 
+	# get remote, if differnt
+	local branch_remote=`gitflow_get_remote $BRANCH`
+
 	echo
 	echo "Summary of actions:"
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
 	echo "- You are now on branch '$BRANCH'"
+	[ ! -z $branch_remote ] && echo "- Changes will be pushed to $branch_remote"
 	echo ""
 	echo "Now, start committing on your feature. When done, use:"
 	echo ""
@@ -339,6 +344,9 @@ cmd_finish() {
 		echo
 		exit 1
 	fi
+
+	# cleanup git remote, if any
+	gitflow_remove_remote "feature-${BRANCH#${PREFIX}}"
 
 	# when no merge conflict is detected, just clean up the feature branch
 	helper_finish_cleanup
@@ -527,4 +535,21 @@ cmd_pull() {
 		git_do checkout -q "$BRANCH" || die "Checking out new local branch failed."
 		echo "Created local branch $BRANCH based on $REMOTE's $BRANCH."
 	fi
+}
+
+
+cmd_remoteset() {
+	local set_remote=$1
+
+	# get current branch and extract feature name
+	local current_branch=$(git_current_branch)
+	local feature_name=${current_branch#${PREFIX}}
+
+	# set new remote in settings
+	git config gitflow.remote."feature-$feature_name" "$set_remote"
+
+	# set new remote for branch and remote
+	gitflow_set_remote "feature-$feature_name" $current_branch
+
+	echo "Set remote for feature '$feature_name' to '$set_remote'"
 }

--- a/git-flow-init
+++ b/git-flow-init
@@ -309,6 +309,31 @@ cmd_default() {
 		git_do config gitflow.prefix.versiontag "$prefix"
 	fi
 
+	# Ask the user for branch <-> remote relations
+	if flag force || \
+		! git config --get gitflow.remote.master >/dev/null 2>&1 ||
+		! git config --get gitflow.remote.release >/dev/null 2>&1 ||
+		! git config --get gitflow.remote.develop >/dev/null 2>&1; then
+		echo
+		echo "Do you use multiple remotes?"
+	fi
+
+	local default_remote=`git remote | head -1`
+	for context in `echo "master release develop"`; do
+		if ! git config --get gitflow.remote.$context >/dev/null 2>&1 || flag force; then
+			printf "Remote for $context [$default_remote] "
+			if noflag defaults; then
+				read answer
+			else
+				printf "\n"
+			fi
+			[ "$answer" = "-" ] && prefix=$default_remote || prefix=${answer:-$default_remote}
+			git_do config gitflow.remote.$context "$prefix"
+		fi
+	done
+	gitflow_set_remote "master" $master_branch
+	gitflow_set_remote "develop" $develop_branch 
+
 
 	# TODO: what to do with origin?
 }

--- a/git-flow-release
+++ b/git-flow-release
@@ -175,13 +175,13 @@ cmd_start() {
 
 	# set remote, if any
 	gitflow_set_remote "release" $BRANCH
-	local branch_remote=`gitflow_get_remote $BRANCH`
+	branch_remote=`gitflow_get_remote $BRANCH`
 
 	echo
 	echo "Summary of actions:"
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
 	echo "- You are now on branch '$BRANCH'"
-	[ ! -z $branch_remote ] && echo "- Changes will be pushed to $branch_remote"
+	[ ! -z "$branch_remote" ] && echo "- Changes will be pushed to $branch_remote"
 	echo
 	echo "Follow-up actions:"
 	echo "- Bump the version number now!"

--- a/git-flow-release
+++ b/git-flow-release
@@ -173,10 +173,15 @@ cmd_start() {
 	# create branch
 	git_do checkout -b "$BRANCH" "$BASE"
 
+	# set remote, if any
+	gitflow_set_remote "release" $BRANCH
+	local branch_remote=`gitflow_get_remote $BRANCH`
+
 	echo
 	echo "Summary of actions:"
 	echo "- A new branch '$BRANCH' was created, based on '$BASE'"
 	echo "- You are now on branch '$BRANCH'"
+	[ ! -z $branch_remote ] && echo "- Changes will be pushed to $branch_remote"
 	echo
 	echo "Follow-up actions:"
 	echo "- Bump the version number now!"

--- a/gitflow-common
+++ b/gitflow-common
@@ -249,6 +249,72 @@ gitflow_resolve_nameprefix() {
 }
 
 #
+# gitflow_set_remote
+#
+# Inputs:
+# $1 = name of the remote context, eg "develop" or "release"
+# $2 = name of the branch for which the remote is to be set
+#
+# Configures remote value of branch and possibly the remote push target.
+# Reads "gitflow.remote.*".
+#
+gitflow_set_remote() {
+	local remote_context=$1
+	local branch_name=$2
+	local remote_name=`git config --get gitflow.remote.$remote_context`
+	if [ ! -z $remote_name -a ! -z $branch_name ]; then
+		local remote_branch=`echo $remote_name | awk -F: '{print $2}'`
+		[ -z $remote_branch ] || remote_name=`echo $remote_name | awk -F: '{print $1}'`
+		git config branch.$branch_name.remote $remote_name
+		if [ -z $remote_branch ]; then
+			git config remote.$remote_name.push refs/heads/$branch_name:refs/heads/$branch_name
+		else
+			git config remote.$remote_name.push refs/heads/$branch_name:refs/heads/$remote_branch
+		fi
+	fi
+}
+
+#
+# gitflow_get_remote
+#
+# Inputs:
+# $1 = name of the branch for which the remote is to be set
+#
+# Returns name of the remote and possibly the push reference
+#    1) development
+#    2) development [refs/heads/develop -> refs/heads/master]
+#
+gitflow_get_remote() {
+	local branch_name=$1
+	local remote=`git config --get branch.$branch_name.remote`
+	if [ ! -z $remote ]; then
+		local push_ref=`git config --get remote.$remote.push`
+		if [ -z $push_ref ]; then
+			echo $remote
+		else
+			push_from=`echo $push_ref | awk -F: '{print $1}'`
+			push_to=`echo $push_ref | awk -F: '{print $2}'`
+			echo "$remote [$push_from -> $push_to]"
+		fi
+	else
+		echo ""
+	fi
+}
+
+#
+# gitflow_remove_remote
+#
+# Inputs:
+# $1 = name of the remote context, eg "develop" or "release"
+#
+# Deletes gitflow.<remote-context> from git config
+#
+gitflow_remove_remote() {
+	local remote_context=$1
+	git config --unset gitflow.remote.$remote_context 2>/dev/null
+}
+
+#
 # Assertions for use in git-flow subcommands
 #
 


### PR DESCRIPTION
Using git flow with multiple remotes, eg in a web development scenario. At least the master, the (current) release and the develop branch should be deployed in a different remote repositoy.

Therefore a new gitflow configuration is introduced:
[gitflow "remote"]
master = origin
release = origin
develop = origin
...

1) Init
The init is extended so that a remote for master, release and develop can be entered. The remotes need to be added before using "git remote add ..". Also a different branch can be chosen.

$ git clone git@my-master:repo.git
$ git remote add my-staging git@my-staging:repo.git
$ git remote add my-develop git@my-develop:repo.git
$ git flow init
Which branch should be used for bringing forth production releases?
- master
  Branch name for production releases: [master] 
  Branch name for "next release" development: [develop] 

How to name your supporting branch prefixes?
Feature branches? [feature/] 
Release branches? [release/] 
Hotfix branches? [hotfix/] 
Support branches? [support/] 
Version tag prefix? [] 

Do you use multiple remotes?
Remote for master [origin] 
Remote for release [origin] my-staging:master
Remote for develop [origin] my-develop:master

2) Features
Also a remote (+branch) per feature can be set:

$ git flow feature start my-feature
$ git flow feature remoteset the-remote:the-branch
..
