### PR TITLE
Feature/bug/free bsd init compat

### DIFF
--- a/Changes.mdown
+++ b/Changes.mdown
@@ -19,6 +19,8 @@ Release date: **not yet**
 
 * Add package installer for the Windows platform.
 
+* Fixing "init: Operation not permitted" bug on FreeBSD.
+
 0.4.1:
 -----
 Release date: **2011/02/04**

--- a/git-flow
+++ b/git-flow
@@ -37,7 +37,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-# set this to workaround expr problems in shFlags on freebsd
+# set this to workaround expr problems in shFlags on FreeBSD
 if uname -s | egrep -iq 'bsd'; then export EXPR_COMPAT=1; fi
 
 # enable debug mode
@@ -115,7 +115,7 @@ main() {
 
 	# run the specified action
   if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
-    init
+    initialize
   fi
   cmd_$SUBACTION "$@"
 }

--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     initialize
   fi
   cmd_$SUBACTION "$@"

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-init() {
+initialize() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-init() {
+initialize() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings

--- a/git-flow-release
+++ b/git-flow-release
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-init() {
+initialize() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings

--- a/git-flow-support
+++ b/git-flow-support
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-init() {
+initialize() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings


### PR DESCRIPTION
Fixing "init: Operation not permitted" bug on FreeBSD and OpenBSD.

init is an UNIX command to control the boot sequence.
