### PR TITLE
Added New Subcommand: git flow develop

### DIFF
--- a/git-flow-develop
+++ b/git-flow-develop
@@ -44,11 +44,15 @@ init() {
 
 usage() {
 	echo "usage: git flow develop on <branch> [<prefix>]"
+	echo "       git flow develop reset"
 }
 
 cmd_on() {
+	local old_develop_branch
 	local new_develop_branch
 	local branch_created=false
+	local feature_prefix_changed=false
+	old_develop_branch = "$(git config --get gitflow.branch.develop)"
 	new_develop_branch=$1
 
 	# Create the new develop branch if it doesn't exist
@@ -57,27 +61,49 @@ cmd_on() {
 		git_do branch "$new_develop_branch" develop
 	fi
 	# Set the default develop branch to that branch
+	git_do config gitflow.branch.develop_old "$old_develop_branch"
 	git_do config gitflow.branch.develop "$new_develop_branch"
 
 	# Figure out what to set the new feature prefix to
 	local new_feature_prefix
 	if [ $2 ]; then
 		new_feature_prefix=$2
-	else
-		new_feature_prefix="$(git config --get gitflow.prefix.feature)$new_develop_branch/"
+		git_do config gitflow.prefix.feature_old "$(git config --get gitflow.prefix.feature)"
+		git_do config gitflow.prefix.feature "$new_feature_prefix"
+		feature_prefix_changed=true
 	fi
-	git_do config gitflow.prefix.feature "$new_"
 
 
 	# Print out sumary of actions
 	echo "Summary of actions:"
 	if $branch_created; then
-		echo "	Branch created: $new_develop_branch"
+		echo "    Branch created: $new_develop_branch"
 	fi
-	echo "	Set default develop branch to: $new_develop_branch"
-	echo "  Set default feature branch prefix to: $new_feature_prefix"
+	echo "    Set default develop branch to: $new_develop_branch"
+	if $feature_prefix_changed; then
+		echo "    Set default feature branch prefix to: $new_feature_prefix"
+	fi
+}
+
+cmd_reset() {
+	local old_develop_branch
+	old_develop_branch="$(git config --get gitflow.branch.develop_old 2>/dev/null)" ||
+		exit 0  # If the develop_old config key is not set, exit cleanly
+	git_do config gitflow.branch.develop "$old_develop_branch"
+	git_do config --unset gitflow.branch.develop_old
+
+	local old_feature_branch
+	old_feature_branch="$(git config --get gitflow.prefix.feature_old 2>/dev/null)" ||
+		exit 0  # If the feature_old config key is not set, exit cleanly
+	git_do config gitflow.prefix.feature "$old_feature_branch"
+	git_do config --unset gitflow.prefix.feature_old
 }
 
 cmd_default() {
 	usage
+}
+
+cmd_help() {
+	usage
+	exit 0
 }

--- a/git-flow-develop
+++ b/git-flow-develop
@@ -1,0 +1,83 @@
+#
+# git-flow -- A collection of Git extensions to provide high-level
+# repository operations for Vincent Driessen's branching model.
+#
+# Original blog post presenting this model is found at:
+#    http://nvie.com/git-model
+#
+# Feel free to contribute to this project at:
+#    http://github.com/nvie/gitflow
+#
+# Copyright 2010 Vincent Driessen. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+# 
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY VINCENT DRIESSEN ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+# EVENT SHALL VINCENT DRIESSEN OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# 
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of Vincent Driessen.
+#
+
+init() {
+	require_git_repo
+	require_gitflow_initialized
+	gitflow_load_settings
+}
+
+usage() {
+	echo "usage: git flow develop on <branch> [<prefix>]"
+}
+
+cmd_on() {
+	local new_develop_branch
+	local branch_created=false
+	new_develop_branch=$1
+
+	# Create the new develop branch if it doesn't exist
+	if ! git_local_branch_exists "$new_develop_branch"; then
+		branch_created=true
+		git_do branch "$new_develop_branch" develop
+	fi
+	# Set the default develop branch to that branch
+	git_do config gitflow.branch.develop "$new_develop_branch"
+
+	# Figure out what to set the new feature prefix to
+	local new_feature_prefix
+	if [ $2 ]; then
+		new_feature_prefix=$2
+	else
+		new_feature_prefix="$(git config --get gitflow.prefix.feature)$new_develop_branch/"
+	fi
+	git_do config gitflow.prefix.feature "$new_"
+
+
+	# Print out sumary of actions
+	echo "Summary of actions:"
+	if $branch_created; then
+		echo "	Branch created: $new_develop_branch"
+	fi
+	echo "	Set default develop branch to: $new_develop_branch"
+	echo "  Set default feature branch prefix to: $new_feature_prefix"
+}
+
+cmd_default() {
+	usage
+}

--- a/git-flow-develop
+++ b/git-flow-develop
@@ -61,14 +61,14 @@ cmd_on() {
 		git_do branch "$new_develop_branch" develop
 	fi
 	# Set the default develop branch to that branch
-	git_do config gitflow.branch.develop_old "$old_develop_branch"
+	git_do config gitflow.branch.develop-old "$old_develop_branch"
 	git_do config gitflow.branch.develop "$new_develop_branch"
 
 	# Figure out what to set the new feature prefix to
 	local new_feature_prefix
 	if [ $2 ]; then
 		new_feature_prefix=$2
-		git_do config gitflow.prefix.feature_old "$(git config --get gitflow.prefix.feature)"
+		git_do config gitflow.prefix.feature-old "$(git config --get gitflow.prefix.feature)"
 		git_do config gitflow.prefix.feature "$new_feature_prefix"
 		feature_prefix_changed=true
 	fi
@@ -87,16 +87,16 @@ cmd_on() {
 
 cmd_reset() {
 	local old_develop_branch
-	old_develop_branch="$(git config --get gitflow.branch.develop_old 2>/dev/null)" ||
-		exit 0  # If the develop_old config key is not set, exit cleanly
+	old_develop_branch="$(git config --get gitflow.branch.develop-old 2>/dev/null)" ||
+		exit 0  # If the develop-old config key is not set, exit cleanly
 	git_do config gitflow.branch.develop "$old_develop_branch"
-	git_do config --unset gitflow.branch.develop_old
+	git_do config --unset gitflow.branch.develop-old
 
 	local old_feature_branch
-	old_feature_branch="$(git config --get gitflow.prefix.feature_old 2>/dev/null)" ||
-		exit 0  # If the feature_old config key is not set, exit cleanly
+	old_feature_branch="$(git config --get gitflow.prefix.feature-old 2>/dev/null)" ||
+		exit 0  # If the feature-old config key is not set, exit cleanly
 	git_do config gitflow.prefix.feature "$old_feature_branch"
-	git_do config --unset gitflow.prefix.feature_old
+	git_do config --unset gitflow.prefix.feature-old
 }
 
 cmd_default() {


### PR DESCRIPTION
Usage:

```
git flow develop on <branch> [<new_feature_prefix>]
git flow develop reset
```

Rationale for this new command:

In large projects, branches are used, in addition to features,
for different lines of development, ie an OS X branch and a 
Windows branch for a desktop application. In addition, it can
be useful for especially large or long-lived feature-branches to have
"sub-feature-branches" that represent distinct components of the
larger feature. For both of these purposes, a command that
allows easy switching of the default develop branch and
(optionally) also the feature-branch prefix can be useful

What this command does:
- Creates branch if it doesn't exist already, and sets it as the
  develop branch in .git/config
- If it's specified, sets new_feature_prefix as the default
  feature-branch prefix
