### PR TITLE
Updated version of #200: Added options (-m and -a) on feature finish action that allow to change default merge message.

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -313,39 +313,41 @@ cmd_finish() {
 	fi
 
 	# merge into BASE
-	local append_message=""
+	local APPEND_MESSAGE=""
 	# get and evaluate feature finish append message, since it can contain custom subcommands that use $BRANCH variable
 	if [ "$FLAGS_append_message" != "" ]; then
-		eval "append_message=\"$FLAGS_append_message\""
+		eval "APPEND_MESSAGE=\"$FLAGS_append_message\""
 	# no command line message defined, trying default from config
 	elif [ "$(git config gitflow.feature.finish.append)" != "" ]; then
-		eval "append_message=\"$(git config gitflow.feature.finish.append) \""
+		eval "APPEND_MESSAGE=\"$(git config gitflow.feature.finish.append) \""
 	fi
 
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
-		if [ "$append_message" != "" ]; then
+		if [ "$APPEND_MESSAGE" != "" ]; then
 			git_do checkout "$BRANCH"
-			git_do commit --amend -m "$(printf "%s\n\n%s" "$(git log -1 --pretty=%s)" "$append_message")"
+			git_do commit --amend -m "$(printf "%s\n\n%s" "$(git log -1 --pretty=%s)" "$APPEND_MESSAGE")"
 		fi
 		git_do checkout "$DEVELOP_BRANCH"
 		git_do merge --ff "$BRANCH"
 	else
-		local opts=""
+		local OPTS=""
 		if [ "$FLAGS_message" != "" ]; then
-			opts="-m$FLAGS_message"
-		elif [ "$append_message" != "" ]; then
-			opts="$(printf "%s\n\n%s" "-mMerge branch $BRANCH into $DEVELOP_BRANCH." "$append_message")"
+			OPTS="-m$FLAGS_message"
+		elif [ "$APPEND_MESSAGE" != "" ]; then
+			OPTS="$(printf "%s\n\n%s" "-mMerge branch $BRANCH into $DEVELOP_BRANCH." "$APPEND_MESSAGE")"
 		fi
 		
 		git_do checkout "$DEVELOP_BRANCH"
 
 		if flag squash; then
 			git_do merge --squash "$BRANCH"
-			git_do commit "$opts"
+			git_do commit "$OPTS"
 			# keep our branch since it was squashed and not fully merged
 			FLAGS_keep="$FLAGS_TRUE"
+		elif [ "$OPTS" != "" ]; then
+			git_do merge --no-ff "$OPTS" "$BRANCH"
 		else
-			git_do merge --no-ff "$opts" "$BRANCH"
+			git_do merge --no-ff "$BRANCH"
 		fi
 	fi
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -342,8 +342,10 @@ cmd_finish() {
 		if flag squash; then
 			git_do merge --squash "$BRANCH"
 			git_do commit "$opts"
-		else 
-			git_do merge "$opts" --no-ff "$BRANCH"
+			# keep our branch since it was squashed and not fully merged
+			FLAGS_keep="$FLAGS_TRUE"
+		else
+			git_do merge --no-ff "$opts" "$BRANCH"
 		fi
 	fi
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -235,6 +235,8 @@ cmd_finish() {
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
 	DEFINE_boolean squash false "squash feature during merge" S
+	DEFINE_string  message "" "custom merge message" m
+	DEFINE_string  append_message ""  "append a message to default merge message" a
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -311,16 +313,37 @@ cmd_finish() {
 	fi
 
 	# merge into BASE
-	git_do checkout "$DEVELOP_BRANCH"
+	local append_message=""
+	# get and evaluate feature finish append message, since it can contain custom subcommands that use $BRANCH variable
+	if [ "$FLAGS_append_message" != "" ]; then
+		eval "append_message=\"$FLAGS_append_message\""
+	# no command line message defined, trying default from config
+	elif [ "$(git config gitflow.feature.finish.append)" != "" ]; then
+		eval "append_message=\"$(git config gitflow.feature.finish.append) \""
+	fi
+
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
+		if [ "$append_message" != "" ]; then
+			git_do checkout "$BRANCH"
+			git_do commit --amend -m "$(echo "$(git log -n 1 --pretty=%s)\n\n$append_message")"
+		fi
+		git_do checkout "$DEVELOP_BRANCH"
 		git_do merge --ff "$BRANCH"
 	else
-		if noflag squash; then
-		    git_do merge --no-ff "$BRANCH"
-		else
+		local opts=""
+		if [ "$FLAGS_message" != "" ]; then
+			opts="-m '$FLAGS_message'"
+		elif [ "$append_message" != "" ]; then
+			opts=$(echo "-m 'Merge branch $BRANCH into $DEVELOP_BRANCH.\n\n$append_message'")
+		fi
+		
+		git_do checkout "$DEVELOP_BRANCH"
+
+		if flag squash; then
 			git_do merge --squash "$BRANCH"
-			git_do commit
-			git_do merge "$BRANCH"
+			git_do commit "$opts"
+		else 
+			git_do merge "$opts" --no-ff "$BRANCH"
 		fi
 	fi
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -325,16 +325,16 @@ cmd_finish() {
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
 		if [ "$append_message" != "" ]; then
 			git_do checkout "$BRANCH"
-			git_do commit --amend -m "$(echo "$(git log -n 1 --pretty=%s)\n\n$append_message")"
+			git_do commit --amend -m "$(printf "%s\n\n%s" "$(git log -1 --pretty=%s)" "$append_message")"
 		fi
 		git_do checkout "$DEVELOP_BRANCH"
 		git_do merge --ff "$BRANCH"
 	else
 		local opts=""
 		if [ "$FLAGS_message" != "" ]; then
-			opts="-m '$FLAGS_message'"
+			opts="-m$FLAGS_message"
 		elif [ "$append_message" != "" ]; then
-			opts=$(echo "-m 'Merge branch $BRANCH into $DEVELOP_BRANCH.\n\n$append_message'")
+			opts="$(printf "%s\n\n%s" "-mMerge branch $BRANCH into $DEVELOP_BRANCH." "$append_message")"
 		fi
 		
 		git_do checkout "$DEVELOP_BRANCH"


### PR DESCRIPTION
What was changed according to #200:
- code is updated to work with --squash option
- fixed bug #241 that produced extra merge after squashing a commit
- feature branch is not deleted anymore after squashing, since there was no merge, so it can be deleted cleanly

Description of #200 (just for the convenience):

Those are:
- custom merge message option (-m)
- custom appended message to a default merge message (-a)
- default addition to -a option via git config option gitflow.feature.finish.append.

Why is this needed?
Some (maybe many) bugtrackers allow closing issues by mentioning them in the commit messages, like `#VM-123 fixed`. That's cool and we like do that. But in our company before closing task the code (a branch) should pass code review. So it would be convenient to automatically add some text into a merge message when branch is merged into mainstream (develop), so task can be closed.

How to test: 
Create test repo with the following: 

```
mkdir /tmp/repo; cd /tmp/repo; git flow init -d; git config gitflow.feature.finish.append '#VM-$(echo $BRANCH | grep -oP "\d+") fixed'; touch README; git add . ; git commit -m "initial commit"
```

As you may noted, config option will be `eval`uated on run, so user basically can use some template logic based on branch-name, that's very convenient.

Test fast-forward merges with following:

```
git flow feature start vm-1234-test; echo commit >> README ; git commit -am 'commit'; git flow feature finish; git log --shortstat -n 1
```

You should see git flow output and something like that in the end:

```
commit 3d9039fb58bf05537ca9de00052d4d20570783a2
Author: Shein Alexey <confik@gmail.com>
Date:   Wed Mar 14 02:55:36 2012 +0500

    commit
    #VM-1234 fixed

 1 files changed, 1 insertions(+), 0 deletions(-)
```

Note #VM-1234 fixed, that was added by my patch.

Test recursive merges with following: 

```
git flow feature start vm-1234-test; echo commit >> README ; git commit -am 'commit'; echo commit >> README ; git commit -am 'commit'; echo commit >> README ; git commit -am 'commit'; git flow feature finish; git log --shortstat  -n 1
```

You should see git flow output and something like that:

```
commit eb527929d89fc1f0b137664c8077f05f5a74dd72
Merge: 3d9039f 319cb16
Author: Shein Alexey <confik@gmail.com>
Date:   Wed Mar 14 02:57:25 2012 +0500

    Merge branch feature/vm-1234-test into develop.
    #VM-1234 fixed

commit 319cb16e5f4a2d4e15c3b8283a4a6c0846760a77
```

You can also specify custom merge message via -m option and append message via -a option if you need some more flexibility.
