### PR TITLE
Fix second broken link to original blog post

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -2,7 +2,7 @@ git-flow
 ========
 
 A collection of Git extensions to provide high-level repository operations
-for Vincent Driessen's [branching model](http://nvie.com/git-model "original
+for Vincent Driessen's [branching model](http://nvie.com/posts/a-successful-git-branching-model/ "original
 blog post").
 
 


### PR DESCRIPTION
The previous change (9c48e05) fixed one of the two places in the file that had the outdated link to the original blog post.  This change just fixes the other one as well.
