### PR TITLE
Fixing another broken link to the blog post

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -2,7 +2,7 @@ git-flow
 ========
 
 A collection of Git extensions to provide high-level repository operations
-for Vincent Driessen's [branching model](http://nvie.com/git-model "original
+for Vincent Driessen's [branching model](http://nvie.com/posts/a-successful-git-branching-model/ "original
 blog post").
 
 


### PR DESCRIPTION
There was a second broken link to the branching model blog post in the README
