### PR TITLE
Add archival feature tagging on feature finish (replacement of previous pull request)

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -46,7 +46,7 @@ init() {
 usage() {
 	echo "usage: git flow feature [list] [-v]"
 	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFkDS] [<name|nameprefix>]"
+	echo "       git flow feature finish [-rFkDSA] [<name|nameprefix>]"
 	echo "       git flow feature publish <name>"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
@@ -235,6 +235,7 @@ cmd_finish() {
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
 	DEFINE_boolean squash false "squash feature during merge" S
+	DEFINE_boolean archivefeature false "create archive tag for feature" A
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -310,6 +311,27 @@ cmd_finish() {
 		fi
 	fi
 
+	# Tag the head of the feature branch for the archives
+	if flag archivefeature || [ "true" = "$(git config --bool gitflow.options.archivefeatures)" ]; then
+		if ! ARCHIVE_PREFIX=$(git config --get gitflow.prefix.archivetag); then
+			warn "You have not set an archive prefix. Please set"
+			warn "gitflow.prefix.archivetag in your config (default archive/)."
+			exit 1
+		fi
+		local TAG="$ARCHIVE_PREFIX$BRANCH"
+		if ! git tag -am "$BRANCH" "$TAG" "$BRANCH"; then
+			warn "Finish was aborted because the archive tag could not be added."
+			warn "You must provide a tag message. If the tag already exists, read on."
+			warn "You may wish to delete or rename a previous version of the tag."
+			warn "To delete it, do this:"
+			warn "    git tag -d $TAG"
+			warn "To rename it, do this:"
+			warn "    git tag -a ${TAG}_new_name $TAG"
+			warn "then delete it as shown above."
+			exit 1
+		fi
+	fi
+
 	# merge into BASE
 	git_do checkout "$DEVELOP_BRANCH"
 	if [ "$(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
@@ -371,6 +393,9 @@ helper_finish_cleanup() {
 		echo "- Feature branch '$BRANCH' is still available"
 	else
 		echo "- Feature branch '$BRANCH' has been removed"
+	fi
+	if flag archivefeature || [ "true" = "$(git config --bool gitflow.options.archivefeatures)" ]; then
+		echo "- Feature branch '$BRANCH' has been archived as a tag"
 	fi
 	echo "- You are now on branch '$DEVELOP_BRANCH'"
 	echo

--- a/git-flow-init
+++ b/git-flow-init
@@ -234,6 +234,7 @@ cmd_default() {
 	   ! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
 	   ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
 	   ! git config --get gitflow.prefix.support >/dev/null 2>&1 || 
+	   ! git config --get gitflow.prefix.archivetag >/dev/null 2>&1 ||
 	   ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1; then
 		echo
 		echo "How to name your supporting branch prefixes?"
@@ -307,6 +308,34 @@ cmd_default() {
 		fi
 		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
 		git_do config gitflow.prefix.versiontag "$prefix"
+	fi
+
+
+	# Archive tag prefix
+	if ! git config --get gitflow.prefix.archivetag >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --get gitflow.prefix.archivetag || echo archive/)
+		printf "Archive tag prefix? [$default_suggestion] "
+		if noflag defaults; then
+			read answer
+		else
+			printf "\n"
+		fi
+		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+		git config gitflow.prefix.archivetag "$prefix"
+	fi
+
+
+	# Archive tag prefix
+	if ! git config --get gitflow.prefix.archivetag >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --get gitflow.prefix.archivetag || echo archive/)
+		printf "Archive tag prefix? [$default_suggestion] "
+		if noflag defaults; then
+			read answer
+		else
+			printf "\n"
+		fi
+		[ "$answer" = "-" ] && prefix= || prefix=${answer:-$default_suggestion}
+		git config gitflow.prefix.archivetag "$prefix"
 	fi
 
 

--- a/git-flow-version
+++ b/git-flow-version
@@ -36,7 +36,7 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-GITFLOW_VERSION=0.4.2-pre
+GITFLOW_VERSION=0.4.1-true-111-g33b2f93+archive-tagging
 
 usage() {
 	echo "usage: git flow version"


### PR DESCRIPTION
When finishing a feature, add a tag with the feature name, prefixed with
the configured archive prefix. Example: a feature named foo would be
archived as archive/feature/foo. The tag is set immediately behind the
merge commit

Having such tags eases resumption of feature branches that are
prematurely finished. They also mark the end of each feature branch in a
way that's easier to find than searching for the final merge commit.

Add a flag to feature finish, -A, that enables archive tagging if it is
not on by default in the config.

Add a new boolean configuration option, gitflow.options.archivefeatures,
which if set true, archives features by default, without specifying -A
on the command line.

Add a new prefix in git flow init: gitflow.prefix.archivetag, with
default archive/

Add a summary message if branch was archive tagged.
