### PR TITLE
Issue#299 : Use the correct link for branching model.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -2,8 +2,7 @@ git-flow
 ========
 
 A collection of Git extensions to provide high-level repository operations
-for Vincent Driessen's [branching model](http://nvie.com/git-model "original
-blog post").
+for Vincent Driessen's [branching model](http://nvie.com/posts/a-successful-git-branching-model/ "original blog post").
 
 
 Getting started


### PR DESCRIPTION
Fixes README.mdown to use the correct link.
