### PR TITLE
Assume current branch where it's omitted and the prefix matches

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -173,12 +173,17 @@ name_or_current() {
 }
 
 parse_args() {
+	local current_branch
 	# parse options
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
 
 	# read arguments into global variables
 	NAME=$1
+	current_branch=`git_current_branch`
+	if [[ $NAME == "" ]] && [[ $current_branch == $PREFIX* ]]; then
+		NAME=${current_branch//$PREFIX/}
+	fi
 	BRANCH=$PREFIX$NAME
 }
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -123,12 +123,17 @@ cmd_help() {
 }
 
 parse_args() {
+	local current_branch
 	# parse options
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
 
 	# read arguments into global variables
 	VERSION=$1
+	current_branch=`git_current_branch`
+	if [[ $VERSION == "" ]] && [[ $current_branch == $PREFIX* ]]; then
+		VERSION=${current_branch//$PREFIX/}
+	fi
 	BRANCH=$PREFIX$VERSION
 }
 

--- a/git-flow-release
+++ b/git-flow-release
@@ -118,12 +118,17 @@ cmd_help() {
 }
 
 parse_args() {
+	local current_branch
 	# parse options
 	FLAGS "$@" || exit $?
 	eval set -- "${FLAGS_ARGV}"
 
 	# read arguments into global variables
 	VERSION=$1
+	current_branch=`git_current_branch`
+	if [[ $VERSION == "" ]] && [[ $current_branch == $PREFIX* ]]; then
+		VERSION=${current_branch//$PREFIX/}
+	fi
 	BRANCH=$PREFIX$VERSION
 }
 


### PR DESCRIPTION
Assume current branch where it's omitted for feature, hotfix, and release branches.
e.g You're on branch "feature/assume-branch-name"
and you type: "git-flow feature publish"
The current branch is assumed and published.
