### PR TITLE
Protect against incorrect init function call.

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ "`type -t init`" = function ]; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
Only call the init function if the function is defined, instead of maintaining a list of commands that define it.  This fixes a bug with the "git flow version" command.

There are already multiple pull requests to fix this bug, for example https://github.com/nvie/gitflow/pull/262 and https://github.com/nvie/gitflow/pull/237), but this one avoids hardcoding the list of command names.
