### PR TITLE
allow 'git flow version' to run without errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ all:
 
 install:
 	@test -f gitflow-shFlags || (echo "Run 'git submodule init && git submodule update' first." ; exit 1 )
-	install -d -m 0755 $(prefix)/bin
-	install -m 0755 $(EXEC_FILES) $(prefix)/bin
-	install -m 0644 $(SCRIPT_FILES) $(prefix)/bin
+	install -d -m 0755 $(DESTDIR)$(prefix)/bin
+	install -m 0755 $(EXEC_FILES) $(DESTDIR)$(prefix)/bin
+	install -m 0644 $(SCRIPT_FILES) $(DESTDIR)$(prefix)/bin
 
 uninstall:
 	test -d $(prefix)/bin && \

--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
Running 'git flow version' emits an error immediately before displaying the version, this is a (very basic) fix for that.
