### PR TITLE
make "git flow release" tag master

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -294,7 +294,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
-			eval git_do tag $opts "$VERSION_PREFIX$VERSION" "$BRANCH" || \
+			eval git_do tag $opts "$VERSION_PREFIX$VERSION" "$MASTER_BRANCH" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -250,7 +250,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
-			eval git_do tag $opts "$tagname" "$BRANCH" || \
+			eval git_do tag $opts "$tagname" "$MASTER_BRANCH" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi


### PR DESCRIPTION
`git flow release` was tagging the last commit in the release branch instead
of master.

This commit makes it tag master (after the merge) instead.

I believe this commit restores the original and intended behavior, which
appears to be changed (probably unintentionally) in commit afb191f7.
