### PR TITLE
Use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git


### PR DESCRIPTION
Makes it easy for people behind a firewall install it via tools like homebrew.
