### PR TITLE
Improve using current branch as a name throughout git-flow

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -47,7 +47,7 @@ usage() {
 	echo "usage: git flow feature [list] [-v]"
 	echo "       git flow feature start [-F] <name> [<base>]"
 	echo "       git flow feature finish [-rFkDS] [<name|nameprefix>]"
-	echo "       git flow feature publish <name>"
+	echo "       git flow feature publish [<name>]"
 	echo "       git flow feature track <name>"
 	echo "       git flow feature diff [<name|nameprefix>]"
 	echo "       git flow feature rebase [-i] [<name|nameprefix>]"
@@ -378,7 +378,7 @@ helper_finish_cleanup() {
 
 cmd_publish() {
 	parse_args "$@"
-	expand_nameprefix_arg
+	expand_nameprefix_arg_or_current
 
 	# sanity checks
 	require_clean_working_tree

--- a/git-flow-release
+++ b/git-flow-release
@@ -48,8 +48,8 @@ usage() {
 	echo "usage: git flow release [list] [-v]"
 	echo "       git flow release start [-F] <version> [<base>]"
 	echo "       git flow release finish [-FsumpkS] <version>"
-	echo "       git flow release publish <name>"
-	echo "       git flow release track <name>"
+	echo "       git flow release publish <version>"
+	echo "       git flow release track <version>"
 }
 
 cmd_default() {
@@ -135,6 +135,24 @@ require_version_arg() {
 	fi
 }
 
+use_current_release_branch_name() {
+	local current_branch=$(git_current_branch)
+	if startswith "$current_branch" "$PREFIX"; then
+		BRANCH=$current_branch
+		VERSION=${BRANCH#$PREFIX}
+	else
+		warn "The current HEAD is no release branch."
+		warn "Please specify a <name> argument."
+		exit 1
+	fi
+}
+
+version_or_current() {
+	if [ -z "$VERSION" ]; then
+		use_current_release_branch_name
+	fi
+}
+
 require_base_is_on_develop() {
 	if ! git_do branch --no-color --contains "$BASE" 2>/dev/null \
 			| sed 's/[* ] //g' \
@@ -199,6 +217,7 @@ cmd_finish() {
 	DEFINE_boolean squash false "squash release during merge" S
 
 	parse_args "$@"
+	version_or_current
 	require_version_arg
 
 	# handle flags that imply other flags
@@ -319,6 +338,7 @@ cmd_finish() {
 
 cmd_publish() {
 	parse_args "$@"
+	version_or_current
 	require_version_arg
 
 	# sanity checks


### PR DESCRIPTION
There were several context in which using the name of
the current branch is beneficial.
