### PR TITLE
add configurable ability to *always* gpg sign releases & hotfixes

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -42,6 +42,24 @@ init() {
   gitflow_load_settings
   VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
   PREFIX=$(git config --get gitflow.prefix.hotfix)
+  if ! git config --get --bool gitflow.always-sign >/dev/null 2>&1; then
+    FORCE_SIGN=$(git config --get gitflow.always-sign 2>/dev/null)
+    if [ "$FORCE_SIGN" != "" ]; then
+      if echo "$FORCE_SIGN" | grep -q hotfix; then
+        FORCE_SIGN=$FLAGS_TRUE
+      else
+        FORCE_SIGN=$FLAGS_FALSE
+      fi
+    else
+      FORCE_SIGN=$FLAGS_FALSE
+    fi
+  else
+    if [ "$(git config --get --bool gitflow.always-sign)" = "true" ]; then
+      FORCE_SIGN=$FLAGS_TRUE
+    else
+      FORCE_SIGN=$FLAGS_FALSE
+    fi
+  fi
 }
 
 usage() {
@@ -250,6 +268,10 @@ cmd_finish() {
 	DEFINE_boolean notag false "don't tag this release" n
 	parse_args "$@"
 	require_version_arg
+
+	if [ $FORCE_SIGN -eq $FLAGS_TRUE ]; then
+		FLAGS_sign=$FLAGS_TRUE
+	fi
 
 	# handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then

--- a/git-flow-release
+++ b/git-flow-release
@@ -42,6 +42,24 @@ init() {
   gitflow_load_settings
   VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
   PREFIX=$(git config --get gitflow.prefix.release)
+  if ! git config --get --bool gitflow.always-sign >/dev/null 2>&1; then
+    FORCE_SIGN=$(git config --get gitflow.always-sign 2>/dev/null)
+    if [ "$FORCE_SIGN" != "" ]; then
+      if echo "$FORCE_SIGN" | grep -q release; then
+        FORCE_SIGN=$FLAGS_TRUE
+      else
+        FORCE_SIGN=$FLAGS_FALSE
+      fi
+    else
+      FORCE_SIGN=$FLAGS_FALSE
+    fi
+  else
+    if [ "$(git config --get --bool gitflow.always-sign)" = "true" ]; then
+      FORCE_SIGN=$FLAGS_TRUE
+    else
+      FORCE_SIGN=$FLAGS_FALSE
+    fi
+  fi
 }
 
 usage() {
@@ -203,6 +221,10 @@ cmd_finish() {
 
 	# handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then
+		FLAGS_sign=$FLAGS_TRUE
+	fi
+
+	if [ $FORCE_SIGN -eq $FLAGS_TRUE ]; then
 		FLAGS_sign=$FLAGS_TRUE
 	fi
 


### PR DESCRIPTION
It's easy to forget to use `-S` when using `release finish` or `hotfix finish`.

This adds configurable auto-signing via a new git config setting: `gitflow.always-sign`

 If this value is:
- **true**: _Both_ releases and hotfixes will always be signed when finished.
- **hotfix**: All hotfixes will be signed. Releases will only be signed if `-S` is passed on the command line, as per the default.
- **release**: All releases will be signed. Hotfixes will only be signed if `-S` is passed on the command line, as per the default.
- **false**: Auto-signing is disabled. _This is the default behavior if_ gitflow.always-sign _is unset._
