### PR TITLE
Changing installer from http to https. Fixes the following issue:

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="https://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
# > git --version

git version 1.8.1.1
# > git clone http://github.com/nvie/gitflow.git

Cloning into 'gitflow'...
error: RPC failed; result=22, HTTP code = 400
fatal: The remote end hung up unexpectedly

Motivation: "GitHub recently started redirecting http repository access to https"
[Source: http://stackoverflow.com/questions/19006770/git-rpc-failed-result-22-http-code-400]
