### PR TITLE
Fix bug where user's GREP_OPTIONS breaks scripts

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -40,6 +40,9 @@
 # set this to workaround expr problems in shFlags on freebsd
 if uname -s | egrep -iq 'bsd'; then export EXPR_COMPAT=1; fi
 
+# user's GREP_OPTIONS mustn't interfere (e.g. GREP_OPTIONS='-n' breaks things)
+export GREP_OPTIONS=''
+
 # enable debug mode
 if [ "$DEBUG" = "yes" ]; then
 	set -x


### PR DESCRIPTION
When a user has `-n` in their GREP_OPTIONS, grep output suddenly has line numbers in place; the gitflow scripts do not expect that, and break. So, let GREP_OPTIONS be empty inside our scripts. This leaves the user's settings untouched.
