### PR TITLE
fixed no-make installer repo url to be https so it works

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="https://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
i was having error (below) fixed it by adding an s http(s)

root@carter:/campaigns# sh gitflow-installer.sh 
### gitflow no-make installer

Installing git-flow to /usr/local/bin
Cloning repo from GitHub to gitflow
Initialized empty Git repository in /campaigns/gitflow/.git/
error: RPC failed; result=22, HTTP code = 405
