### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2010 Vincent Driessen. All rights reserved.
+Copyright 2010-2014 Vincent Driessen. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
Fix outdated copyright year (updated to 2014).
The copyright year was out of date. Copyright notices must reflect the current year, so this commit updates the listed year to 2014.

See http://www.copyright.gov/circs/circ01.pdf for more info.
