### PR TITLE
Fixed README whitespace in two problematic areas

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -84,7 +84,7 @@ in a Github fork, of course.
 
 To initialize a new repo with the basic branch structure, use:
   
-		git flow init [-d]
+    git flow init [-d]
   
 This will then interactively prompt you with some questions on which branches
 you would like to use as development and production branches, and how you
@@ -107,7 +107,7 @@ The ``-d`` flag will accept all defaults.
 * To push/pull a feature branch to the remote repository, use:
 
   		git flow feature publish <name>
-		  git flow feature pull <remote> <name>
+  		git flow feature pull <remote> <name>
 
 * To list/start/finish release branches, use:
   


### PR DESCRIPTION
Fixed the two spots in the README where the inconsistent whitespace was visible in the Markdown rendering. I could have gone through and normalized everything to spaces, but with the code blocks in <li>s, I figured I'd let sleeping dogs lie, and change things just enough to make it all consistent.
