### PR TITLE
Be protocol-agnostic wrt/ Git URL's

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = ../shFlags.git


### PR DESCRIPTION
Today's sub-module URL scheme is `git://` regardless of whether the top-
level (gitflow) repository.  is SSH (`git@github:...`), HTTPS
(`https://`) or Git socket (`git://`).

This small change uses relative URL's for sub-modules & hence re-use
the top-level repo URL model for the sub-module.
