### PR TITLE
Wrong repo URL in installer

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="https://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
Repo url was using `http` rather then `https`. Git was unable to clone the repository.
