### PR TITLE
flexible bash path via /usr/bin/env

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git-flow make-less installer for *nix systems, by Rick Osborne
 # Based on the git-flow core Makefile:


### PR DESCRIPTION
Hi nvie,

sometimes bash is not located at /bin/bash. This patch makes the installer more flexible by determining the path for bash dynamically.

Cheers,
tpltnt
