### PR TITLE
bugfix: REPO_HOME setting http -> https

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="https://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
hi.

the clone destination github in gitflow-installer.sh I fix from http to https. Please merge if good.
