### PR TITLE
Ensure release tag is created on commit on master branch

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -237,6 +237,9 @@ cmd_finish() {
 				die "There were merge conflicts."
 			git_do commit
 		fi
+	else
+		git_do checkout "$MASTER_BRANCH" || \
+		  die "Could not check out $MASTER_BRANCH."
 	fi
 
 	if noflag notag; then


### PR DESCRIPTION
Before there might be cases where the tag was created on develop because content was already merged. This ensures switching to master branch before tagging.
