### PR TITLE
version: fix error due to missing init function

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBACTION != "version" ]; then
     init
   fi
   cmd_$SUBACTION "$@"


### PR DESCRIPTION
It is not nice to greet the user with the error

```
.../git-flow: line 118: init: command not found
```

before showing the version when the user ran `git flow version`. So
let's not do that, then.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
