### PR TITLE
Override the -F flag on feature/release/hotfix commands

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -199,6 +199,11 @@ cmd_start() {
 	BASE=${2:-$DEVELOP_BRANCH}
 	require_name_arg
 
+  # override "fetch first" argument with git configuration
+  if [ "$FEATURE_FETCH_BEFORE_START" = "true" ]; then
+    FLAGS_fetch=0
+  fi
+
 	# sanity checks
 	require_branch_absent "$BRANCH"
 
@@ -237,6 +242,11 @@ cmd_finish() {
 	DEFINE_boolean squash false "squash feature during merge" S
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
+
+  # override "fetch first" argument with git configuration
+  if [ "$FEATURE_FETCH_BEFORE_FINISH" = "true" ]; then
+    FLAGS_fetch=0
+  fi
 
 	# sanity checks
 	require_branch "$BRANCH"
@@ -285,12 +295,12 @@ cmd_finish() {
 	require_clean_working_tree
 
 	# update local repo with remote changes first, if asked
-	if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
-		if flag fetch; then
-			git_do fetch -q "$ORIGIN" "$BRANCH"
-			git_do fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
-		fi
-	fi
+  if flag fetch; then
+    git_do fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
+    if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
+      git_do fetch -q "$ORIGIN" "$BRANCH"
+    fi
+  fi
 
 	if has "$ORIGIN/$BRANCH" $(git_remote_branches); then
 		require_branches_equal "$BRANCH" "$ORIGIN/$BRANCH"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -164,6 +164,11 @@ cmd_start() {
 	require_base_is_on_master
 	require_no_existing_hotfix_branches
 
+  # override "fetch first" flag with git configuration
+  if [ "$HOTFIX_FETCH_BEFORE_START" = "true" ]; then
+    FLAGS_fetch=0
+  fi
+
 	# sanity checks
 	require_clean_working_tree
 	require_branch_absent "$BRANCH"
@@ -255,6 +260,11 @@ cmd_finish() {
 	if [ "$FLAGS_signingkey" != "" ]; then
 		FLAGS_sign=$FLAGS_TRUE
 	fi
+
+  # override "fetch first" argument with git configuration
+  if [ "$HOTFIX_FETCH_BEFORE_START" = "true" ]; then
+    FLAGS_fetch=0
+  fi
 
 	# sanity checks
 	require_branch "$BRANCH"

--- a/git-flow-release
+++ b/git-flow-release
@@ -159,6 +159,11 @@ cmd_start() {
 	require_base_is_on_develop
 	require_no_existing_release_branches
 
+  # override "fetch first" argument with git configuration
+  if [ "$RELEASE_FETCH_BEFORE_START" = "true" ]; then
+    FLAGS_fetch=0
+  fi
+
 	# sanity checks
 	require_clean_working_tree
 	require_branch_absent "$BRANCH"
@@ -205,6 +210,11 @@ cmd_finish() {
 	if [ "$FLAGS_signingkey" != "" ]; then
 		FLAGS_sign=$FLAGS_TRUE
 	fi
+
+  # override "fetch first" flag with git configuration
+  if [ "$RELEASE_FETCH_BEFORE_START" = "true" ]; then
+    FLAGS_fetch=0
+  fi
 
 	# sanity checks
 	require_branch "$BRANCH"

--- a/gitflow-common
+++ b/gitflow-common
@@ -197,6 +197,12 @@ gitflow_load_settings() {
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
 	export ORIGIN=$(git config --get gitflow.origin || echo origin)
+  export FEATURE_FETCH_BEFORE_FINISH=$(git config --get gitflow.feature.finish.fetch || echo false)
+  export FEATURE_FETCH_BEFORE_START=$(git config --get gitflow.feature.start.fetch || echo false)
+  export HOTFIX_FETCH_BEFORE_FINISH=$(git config --get gitflow.hotfix.finish.fetch || echo false)
+  export HOTFIX_FETCH_BEFORE_START=$(git config --get gitflow.hotfix.start.fetch || echo false)
+  export RELEASE_FETCH_BEFORE_FINISH=$(git config --get gitflow.release.finish.fetch || echo false)
+  export RELEASE_FETCH_BEFORE_START=$(git config --get gitflow.release.start.fetch || echo false)
 }
 
 #


### PR DESCRIPTION
So that users may add git configuration to make -F the default behavior, such as:

```
[gitflow "feature.finish"]
  fetch = true
```
