### PR TITLE
correct whitespace error

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -107,7 +107,7 @@ The ``-d`` flag will accept all defaults.
 * To push/pull a feature branch to the remote repository, use:
 
   		git flow feature publish <name>
-		  git flow feature pull <remote> <name>
+		git flow feature pull <remote> <name>
 
 * To list/start/finish release branches, use:
   


### PR DESCRIPTION
The line 
`git flow feature pull <remote> <name>`
had two spaces two much infront of it
