### PR TITLE
<fix>(git-flow-version) added missing init()

### DIFF
--- a/git-flow-version
+++ b/git-flow-version
@@ -36,7 +36,10 @@
 # policies, either expressed or implied, of Vincent Driessen.
 #
 
-GITFLOW_VERSION=0.4.2-pre
+init() {
+  gitflow_load_settings
+  GITFLOW_VERSION=0.4.2-pre
+}
 
 usage() {
 	echo "usage: git flow version"


### PR DESCRIPTION
'git flow' tries to run init which for the other git flow commands is a
shell function.

Since this shell function didn't existed within 'git-flow-version' init
is searched via $PATH which normally yields /sbin/init!!!
