### PR TITLE
Workaround for Cygwin and tag correct branch on finish commands

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -294,7 +294,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
-			eval git_do tag $opts "$VERSION_PREFIX$VERSION" "$BRANCH" || \
+			eval git_do tag $opts "$VERSION_PREFIX$VERSION" "$MASTER_BRANCH" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -250,7 +250,7 @@ cmd_finish() {
 			[ "$FLAGS_signingkey" != "" ] && opts="$opts -u '$FLAGS_signingkey'"
 			[ "$FLAGS_message" != "" ] && opts="$opts -m '$FLAGS_message'"
 			[ "$FLAGS_messagefile" != "" ] && opts="$opts -F '$FLAGS_messagefile'"
-			eval git_do tag $opts "$tagname" "$BRANCH" || \
+			eval git_do tag $opts "$tagname" "$MASTER_BRANCH" || \
 			die "Tagging failed. Please run finish again to retry."
 		fi
 	fi

--- a/gitflow-common
+++ b/gitflow-common
@@ -88,6 +88,7 @@ git_current_branch() {
 }
 
 git_is_clean_working_tree() {
+	git status > /dev/null 2>&1
 	if ! git diff --no-ext-diff --ignore-submodules --quiet --exit-code; then
 		return 1
 	elif ! git diff-index --cached --quiet --ignore-submodules HEAD --; then


### PR DESCRIPTION
New pull request with unwanted changes removed.
