### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -17,7 +17,7 @@ if [ -z "$REPO_NAME" ] ; then
 fi
 
 if [ -z "$REPO_HOME" ] ; then
-	REPO_HOME="http://github.com/nvie/gitflow.git"
+	REPO_HOME="https://github.com/nvie/gitflow.git"
 fi
 
 EXEC_FILES="git-flow"


### PR DESCRIPTION
_git clone_ freezes if HTTPS is not set in **$REPO_HOME** default git URL. (Maybe because it doesn't follow _Location_ headers redirects from github's server)
