### PR TITLE
Making the submodule accessible behind a proxy (via https://)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git


### PR DESCRIPTION
Hi Vincent,

Thank you for GitFlow.

Currently, people can't recursively clone GitFlow behind a proxy. Even if they run

```
git clone --recursive https://github.com/nvie/gitflow.git
```

the submodule was accessed via git:// - (behind a proxy) it fails.

In addition to this pull request, would you update https://github.com/nvie/gitflow/wiki/Manual-installation:

```
change from
git clone --recursive git://github.com/nvie/gitflow.git

to
git clone --recursive https://github.com/nvie/gitflow.git
```

This may be related to https://github.com/nvie/gitflow/issues/104 - I'm not sure.
