### PR TITLE
Fix broken URL in README.mdown

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -17,7 +17,7 @@ Or have a look at one of these screen casts:
 
 * [How to use a scalable Git branching model called git-flow](http://buildamodule.com/video/change-management-and-version-control-deploying-releases-features-and-fixes-with-git-how-to-use-a-scalable-git-branching-model-called-gitflow) (by Build a Module)
 * [A short introduction to git-flow](http://vimeo.com/16018419) (by Mark Derricutt)
-* [On the path with git-flow](http://codesherpas.com/screencasts/on_the_path_gitflow.mov) (by Dave Bock)
+* [On the path with git-flow](https://vimeo.com/37408017) (by Dave Bock)
 
 
 Installing git-flow


### PR DESCRIPTION
The video “On the path with git-flow” by Dave Bock is not anymore available on The CodeSherpas, due to “direct engagement consulting” as per http://codesherpas.com.

Change the URL to point to Vimeo, where it’s still available.