### PR TITLE
Update shFlags submodule to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = git@github.com:kward/shflags.git

--- a/gitflow-shFlags
+++ b/gitflow-shFlags
@@ -1,1 +1,1 @@
-shFlags/src/shflags
+shFlags/shflags


### PR DESCRIPTION
I noticed that the original owner of shflags had a repo at GitHub now, and since nvie/shFlags was just a copy of the old GoogleCode repo, I thought it was a good idea to update to the *real* one.
There are new releases of shflags too.