### PR TITLE
Feature/branch prefixes as subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ debian/files
 debian/*.substvars
 debian/*.debhelper.log
 debian/*/*
+
+# use this directory to init a git repo and test the implementation
+test/

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,5 +20,6 @@ Authors are (ordered by first commit date):
 - Eric Holmes
 - Vedang Manerikar
 - Myke Hines
+- Tobias Szczepanski
 
 Portions derived from other open source works are clearly marked.

--- a/Changes.mdown
+++ b/Changes.mdown
@@ -5,6 +5,11 @@ Release date: **not yet**
 * `git flow init` now detects situations where origin already has gitflow
   branches set up, and behaves accordingly (thanks Emre Berge Ergenekon).
 
+* `git flow init` now asks for a dedicated delimiter, which provides
+  consistency in all branch names. Branch names are constructed as follows:
+  `<prefix><delimiter><name>`.
+  E.g. a custom delimiter `_` leads to `feature_some-feature`
+
 * `git flow feature finish` can now be called without a feature branch
   name(prefix) argument and will finish the current branch, if on any.
 

--- a/git-flow
+++ b/git-flow
@@ -50,15 +50,24 @@ fi
 export GITFLOW_DIR=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
 
 usage() {
+  local featurePrefix=$(git config --get gitflow.prefix.feature)
+  featurePrefix=${featurePrefix:-feature}
+  local releasePrefix=$(git config --get gitflow.prefix.release)
+  releasePrefix=${releasePrefix:-release}
+  local hotfixPrefix=$(git config --get gitflow.prefix.hotfix)
+  hotfixPrefix=${hotfixPrefix:-hotfix}
+  local supportPrefix=$(git config --get gitflow.prefix.support)
+  supportPrefix=${supportPrefix:-support}
+
 	echo "usage: git flow <subcommand>"
 	echo
 	echo "Available subcommands are:"
-	echo "   init      Initialize a new git repo with support for the branching model."
-	echo "   feature   Manage your feature branches."
-	echo "   release   Manage your release branches."
-	echo "   hotfix    Manage your hotfix branches."
-	echo "   support   Manage your support branches."
-	echo "   version   Shows version information."
+	printf '    %s\t%s\n' "init" "Initialize a new git repo with support for the branching model."
+	printf '    %s\t%s\n' "$featurePrefix" "Manage your $featurePrefix branches."
+	printf '    %s\t%s\n' "$releasePrefix" "Manage your $releasePrefix branches."
+	printf '    %s\t%s\n' "$hotfixPrefix" "Manage your $hotfixPrefix branches."
+	printf '    %s\t%s\n' "$supportPrefix" "Manage your $supportPrefix branches."
+	printf '    %s\t%s\n' "version" "Shows version information."
 	echo
 	echo "Try 'git flow <subcommand> help' for details."
 }
@@ -90,6 +99,22 @@ main() {
 
 	# sanity checks
 	SUBCOMMAND="$1"; shift
+
+  # use configured prefix as sub-command
+  case $SUBCOMMAND in
+    init) ;;
+    version) ;;
+    *)
+      if [ "$(git config --get gitflow.prefix.feature)" = "$SUBCOMMAND" ]; then
+        SUBCOMMAND="feature";
+      elif [ "$(git config --get gitflow.prefix.release)" = "$SUBCOMMAND" ]; then
+        SUBCOMMAND="release";
+      elif [ "$(git config --get gitflow.prefix.hotfix)" = "$SUBCOMMAND" ]; then
+        SUBCOMMAND="hotfix";
+      elif [ "$(git config --get gitflow.prefix.support)" = "$SUBCOMMAND" ]; then
+        SUBCOMMAND="support";
+      fi
+  esac
 
 	if [ ! -e "$GITFLOW_DIR/git-flow-$SUBCOMMAND" ]; then
 		usage

--- a/git-flow
+++ b/git-flow
@@ -114,7 +114,7 @@ main() {
 	fi
 
 	# run the specified action
-  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] ; then
+  if [ $SUBACTION != "help" ] && [ $SUBCOMMAND != "init" ] && [ $SUBCOMMAND != "version" ] ; then
     init
   fi
   cmd_$SUBACTION "$@"

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -40,7 +40,8 @@ init() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings
-  PREFIX=$(git config --get gitflow.prefix.feature)
+  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
+  PREFIX="$(git config --get gitflow.prefix.feature)";
 }
 
 usage() {
@@ -66,7 +67,7 @@ cmd_list() {
 	local feature_branches
 	local current_branch
 	local short_names
-	feature_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	feature_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	if [ -z "$feature_branches" ]; then
 		warn "No feature branches exist."
 		warn ""
@@ -77,7 +78,7 @@ cmd_list() {
 		exit 0
 	fi
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
-	short_names=$(echo "$feature_branches" | sed "s ^$PREFIX  g")
+	short_names=$(echo "$feature_branches" | sed "s ^$PREFIX$DELIMITER  g")
 
 	# determine column width first
 	local width=0
@@ -90,7 +91,7 @@ cmd_list() {
 
 	local branch
 	for branch in $short_names; do
-		local fullname=$PREFIX$branch
+		local fullname="$PREFIX$DELIMITER$branch"
 		local base=$(git merge-base "$fullname" "$DEVELOP_BRANCH")
 		local develop_sha=$(git rev-parse "$DEVELOP_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
@@ -135,11 +136,11 @@ expand_nameprefix_arg() {
 
 	local expanded_name
 	local exitcode
-	expanded_name=$(gitflow_resolve_nameprefix "$NAME" "$PREFIX")
+	expanded_name=$(gitflow_resolve_nameprefix "$NAME" "$PREFIX$DELIMITER")
 	exitcode=$?
 	case $exitcode in
 		0) NAME=$expanded_name
-		   BRANCH=$PREFIX$NAME
+		   BRANCH="$PREFIX$DELIMITER$NAME"
 		   ;;
 		*) exit 1 ;;
 	esac
@@ -147,9 +148,9 @@ expand_nameprefix_arg() {
 
 use_current_feature_branch_name() {
 	local current_branch=$(git_current_branch)
-	if startswith "$current_branch" "$PREFIX"; then
+	if startswith "$current_branch" "$PREFIX$DELIMITER"; then
 		BRANCH=$current_branch
-		NAME=${BRANCH#$PREFIX}
+		NAME=${BRANCH#$PREFIX$DELIMITER}
 	else
 		warn "The current HEAD is no feature branch."
 		warn "Please specify a <name> argument."
@@ -160,7 +161,7 @@ use_current_feature_branch_name() {
 expand_nameprefix_arg_or_current() {
 	if [ "$NAME" != "" ]; then
 		expand_nameprefix_arg
-		require_branch "$PREFIX$NAME"
+		require_branch "$PREFIX$DELIMITER$NAME"
 	else
 		use_current_feature_branch_name
 	fi
@@ -179,7 +180,7 @@ parse_args() {
 
 	# read arguments into global variables
 	NAME=$1
-	BRANCH=$PREFIX$NAME
+	BRANCH=$PREFIX$DELIMITER$NAME
 }
 
 parse_remote_name() {
@@ -190,7 +191,7 @@ parse_remote_name() {
 	# read arguments into global variables
 	REMOTE=$1
 	NAME=$2
-	BRANCH=$PREFIX$NAME
+	BRANCH=$PREFIX$DELIMITER$NAME
 }
 
 cmd_start() {
@@ -431,7 +432,7 @@ cmd_diff() {
 		BASE=$(git merge-base "$DEVELOP_BRANCH" "$BRANCH")
 		git diff "$BASE..$BRANCH"
 	else
-		if ! git_current_branch | grep -q "^$PREFIX"; then
+		if ! git_current_branch | grep -q "^$PREFIX$DELIMITER"; then
 			die "Not on a feature branch. Name one explicitly."
 		fi
 
@@ -496,7 +497,7 @@ cmd_pull() {
 	# die if the current feature branch differs from the requested $NAME
 	# argument.
 	local current_branch=$(git_current_branch)
-	if startswith "$current_branch" "$PREFIX"; then
+	if startswith "$current_branch" "$PREFIX$DELIMITER"; then
 		# we are on a local feature branch already, so $BRANCH must be equal to
 		# the current branch
 		avoid_accidental_cross_branch_action || die

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -40,20 +41,21 @@ init() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings
-  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
-  PREFIX="$(git config --get gitflow.prefix.feature)";
 }
 
+DELIMITER="$(git config --get gitflow.prefix.delimiter)";
+PREFIX="$(git config --get gitflow.prefix.feature)";
+
 usage() {
-	echo "usage: git flow feature [list] [-v]"
-	echo "       git flow feature start [-F] <name> [<base>]"
-	echo "       git flow feature finish [-rFkDS] [<name|nameprefix>]"
-	echo "       git flow feature publish <name>"
-	echo "       git flow feature track <name>"
-	echo "       git flow feature diff [<name|nameprefix>]"
-	echo "       git flow feature rebase [-i] [<name|nameprefix>]"
-	echo "       git flow feature checkout [<name|nameprefix>]"
-	echo "       git flow feature pull [-r] <remote> [<name>]"
+	echo "usage: git flow $PREFIX [list] [-v]"
+	echo "       git flow $PREFIX start [-F] <name> [<base>]"
+	echo "       git flow $PREFIX finish [-rFkDS] [<name|nameprefix>]"
+	echo "       git flow $PREFIX publish <name>"
+	echo "       git flow $PREFIX track <name>"
+	echo "       git flow $PREFIX diff [<name|nameprefix>]"
+	echo "       git flow $PREFIX rebase [-i] [<name|nameprefix>]"
+	echo "       git flow $PREFIX checkout [<name|nameprefix>]"
+	echo "       git flow $PREFIX pull [-r] <remote> [<name>]"
 }
 
 cmd_default() {

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -41,6 +41,7 @@ init() {
   require_gitflow_initialized
   gitflow_load_settings
   VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
   PREFIX=$(git config --get gitflow.prefix.hotfix)
 }
 
@@ -63,7 +64,7 @@ cmd_list() {
 	local hotfix_branches
 	local current_branch
 	local short_names
-	hotfix_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	hotfix_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	if [ -z "$hotfix_branches" ]; then
 		warn "No hotfix branches exist."
                 warn ""
@@ -74,7 +75,7 @@ cmd_list() {
 		exit 0
 	fi
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
-	short_names=$(echo "$hotfix_branches" | sed "s ^$PREFIX  g")
+	short_names=$(echo "$hotfix_branches" | sed "s ^$PREFIX$DELIMITER  g")
 
 	# determine column width first
 	local width=0
@@ -87,7 +88,7 @@ cmd_list() {
 
 	local branch
 	for branch in $short_names; do
-		local fullname=$PREFIX$branch
+		local fullname=$PREFIX$DELIMITER$branch
 		local base=$(git merge-base "$fullname" "$MASTER_BRANCH")
 		local master_sha=$(git rev-parse "$MASTER_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
@@ -129,7 +130,7 @@ parse_args() {
 
 	# read arguments into global variables
 	VERSION=$1
-	BRANCH=$PREFIX$VERSION
+	BRANCH=$PREFIX$DELIMITER$VERSION
 }
 
 require_version_arg() {
@@ -149,9 +150,9 @@ require_base_is_on_master() {
 }
 
 require_no_existing_hotfix_branches() {
-	local hotfix_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	local hotfix_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	local first_branch=$(echo ${hotfix_branches} | head -n1)
-	first_branch=${first_branch#$PREFIX}
+	first_branch=${first_branch#$PREFIX$DELIMITER}
 	[ -z "$hotfix_branches" ] || \
 		die "There is an existing hotfix branch ($first_branch). Finish that one first."
 }

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -40,17 +41,18 @@ init() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings
-  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
-  PREFIX=$(git config --get gitflow.prefix.hotfix)
 }
 
+VERSION_PREFIX=$(eval "echo $(git config --get gitflow.prefix.versiontag)")
+DELIMITER="$(git config --get gitflow.prefix.delimiter)";
+PREFIX=$(git config --get gitflow.prefix.hotfix)
+
 usage() {
-	echo "usage: git flow hotfix [list] [-v]"
-	echo "       git flow hotfix start [-F] <version> [<base>]"
-	echo "       git flow hotfix finish [-Fsumpk] <version>"
-	echo "       git flow hotfix publish <version>"
-	echo "       git flow hotfix track <version>"
+	echo "usage: git flow $PREFIX [list] [-v]"
+	echo "       git flow $PREFIX start [-F] <version> [<base>]"
+	echo "       git flow $PREFIX finish [-Fsumpk] <version>"
+	echo "       git flow $PREFIX publish <version>"
+	echo "       git flow $PREFIX track <version>"
 }
 
 cmd_default() {

--- a/git-flow-init
+++ b/git-flow-init
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -261,7 +262,11 @@ cmd_default() {
 		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature)
 		printf "Feature branches? [$default_suggestion] "
 		if noflag defaults; then
-			read answer
+		  local isValid=false
+		  while [ "$isValid" = false ]; do
+			  read answer
+		    is_valid_prefix "$answer" && isValid=true
+		  done
 		else
 			printf "\n"
 		fi
@@ -274,7 +279,11 @@ cmd_default() {
 		default_suggestion=$(git config --get gitflow.prefix.release || echo release)
 		printf "Release branches? [$default_suggestion] "
 		if noflag defaults; then
-			read answer
+			local isValid=false
+		  while [ "$isValid" = false ]; do
+			  read answer
+		    is_valid_prefix "$answer" && isValid=true
+		  done
 		else
 			printf "\n"
 		fi
@@ -288,7 +297,11 @@ cmd_default() {
 		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix)
 		printf "Hotfix branches? [$default_suggestion] "
 		if noflag defaults; then
-			read answer
+			local isValid=false
+		  while [ "$isValid" = false ]; do
+			  read answer
+		    is_valid_prefix "$answer" && isValid=true
+		  done
 		else
 			printf "\n"
 		fi
@@ -302,7 +315,11 @@ cmd_default() {
 		default_suggestion=$(git config --get gitflow.prefix.support || echo support)
 		printf "Support branches? [$default_suggestion] "
 		if noflag defaults; then
-			read answer
+			local isValid=false
+		  while [ "$isValid" = false ]; do
+			  read answer
+		    is_valid_prefix "$answer" && isValid=true
+		  done
 		else
 			printf "\n"
 		fi
@@ -326,6 +343,16 @@ cmd_default() {
 
 
 	# TODO: what to do with origin?
+}
+
+is_valid_prefix() {
+  local prefix=$1
+  if [ "$prefix" = "init" ] || [ "$prefix" = "version" ]; then
+	    echo "Prefix must not be $prefix"
+	    return 1;
+	else
+	    return 0;
+  fi
 }
 
 cmd_help() {

--- a/git-flow-init
+++ b/git-flow-init
@@ -230,6 +230,7 @@ cmd_default() {
 
 	# finally, ask the user for naming conventions (branch and tag prefixes)
 	if flag force || \
+	   ! git config --get gitflow.prefix.delimiter >/dev/null 2>&1 ||
 	   ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || 
 	   ! git config --get gitflow.prefix.release >/dev/null 2>&1 || 
 	   ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || 
@@ -239,11 +240,25 @@ cmd_default() {
 		echo "How to name your supporting branch prefixes?"
 	fi
 
+	local delimiter
+
+	if ! git config --get gitflow.prefix.delimiter >/dev/null 2>&1 || flag force; then
+	  default_suggestion=$(git config --get gitflow.prefix.delimiter || echo /)
+	  printf "Delimiter between prefix and name? [$default_suggestion] "
+	  if noflag defaults; then
+			read answer
+		else
+			printf "\n"
+		fi
+		[ "$answer" = "-" ] && delimiter= || delimiter=${answer:-$default_suggestion}
+		git_do config gitflow.prefix.delimiter "$delimiter"
+  fi
+
 	local prefix
 
 	# Feature branches
 	if ! git config --get gitflow.prefix.feature >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature/)
+		default_suggestion=$(git config --get gitflow.prefix.feature || echo feature)
 		printf "Feature branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -256,7 +271,7 @@ cmd_default() {
 
 	# Release branches
 	if ! git config --get gitflow.prefix.release >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.release || echo release/)
+		default_suggestion=$(git config --get gitflow.prefix.release || echo release)
 		printf "Release branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -270,7 +285,7 @@ cmd_default() {
 
 	# Hotfix branches
 	if ! git config --get gitflow.prefix.hotfix >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix/)
+		default_suggestion=$(git config --get gitflow.prefix.hotfix || echo hotfix)
 		printf "Hotfix branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer
@@ -284,7 +299,7 @@ cmd_default() {
 
 	# Support branches
 	if ! git config --get gitflow.prefix.support >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.support || echo support/)
+		default_suggestion=$(git config --get gitflow.prefix.support || echo support)
 		printf "Support branches? [$default_suggestion] "
 		if noflag defaults; then
 			read answer

--- a/git-flow-release
+++ b/git-flow-release
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -40,17 +41,18 @@ init() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings
-  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
-  PREFIX=$(git config --get gitflow.prefix.release)
 }
 
+VERSION_PREFIX=$(eval "echo $(git config --get gitflow.prefix.versiontag)")
+DELIMITER="$(git config --get gitflow.prefix.delimiter)";
+PREFIX=$(git config --get gitflow.prefix.release)
+
 usage() {
-	echo "usage: git flow release [list] [-v]"
-	echo "       git flow release start [-F] <version> [<base>]"
-	echo "       git flow release finish [-FsumpkS] <version>"
-	echo "       git flow release publish <name>"
-	echo "       git flow release track <name>"
+	echo "usage: git flow $PREFIX [list] [-v]"
+	echo "       git flow $PREFIX start [-F] <version> [<base>]"
+	echo "       git flow $PREFIX finish [-FsumpkS] <version>"
+	echo "       git flow $PREFIX publish <name>"
+	echo "       git flow $PREFIX track <name>"
 }
 
 cmd_default() {

--- a/git-flow-release
+++ b/git-flow-release
@@ -41,6 +41,7 @@ init() {
   require_gitflow_initialized
   gitflow_load_settings
   VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
   PREFIX=$(git config --get gitflow.prefix.release)
 }
 
@@ -63,7 +64,7 @@ cmd_list() {
 	local release_branches
 	local current_branch
 	local short_names
-	release_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	release_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	if [ -z "$release_branches" ]; then
 		warn "No release branches exist."
                 warn ""
@@ -75,7 +76,7 @@ cmd_list() {
 	fi
 
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
-	short_names=$(echo "$release_branches" | sed "s ^$PREFIX  g")
+	short_names=$(echo "$release_branches" | sed "s ^$PREFIX$DELIMITER  g")
 
 	# determine column width first
 	local width=0
@@ -88,7 +89,7 @@ cmd_list() {
 
 	local branch
 	for branch in $short_names; do
-		local fullname=$PREFIX$branch
+		local fullname=$PREFIX$DELIMITER$branch
 		local base=$(git merge-base "$fullname" "$DEVELOP_BRANCH")
 		local develop_sha=$(git rev-parse "$DEVELOP_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
@@ -124,7 +125,7 @@ parse_args() {
 
 	# read arguments into global variables
 	VERSION=$1
-	BRANCH=$PREFIX$VERSION
+	BRANCH=$PREFIX$DELIMITER$VERSION
 }
 
 require_version_arg() {
@@ -144,9 +145,9 @@ require_base_is_on_develop() {
 }
 
 require_no_existing_release_branches() {
-	local release_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	local release_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	local first_branch=$(echo ${release_branches} | head -n1)
-	first_branch=${first_branch#$PREFIX}
+	first_branch=${first_branch#$PREFIX$DELIMITER}
 	[ -z "$release_branches" ] || \
 		die "There is an existing release branch ($first_branch). Finish that one first."
 }

--- a/git-flow-support
+++ b/git-flow-support
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # git-flow -- A collection of Git extensions to provide high-level
 # repository operations for Vincent Driessen's branching model.
@@ -40,17 +41,18 @@ init() {
   require_git_repo
   require_gitflow_initialized
   gitflow_load_settings
-  VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
-  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
-  PREFIX=$(git config --get gitflow.prefix.support)
 }
+
+VERSION_PREFIX=$(eval "echo $(git config --get gitflow.prefix.versiontag)")
+DELIMITER="$(git config --get gitflow.prefix.delimiter)";
+PREFIX=$(git config --get gitflow.prefix.support)
 
 warn "note: The support subcommand is still very EXPERIMENTAL!"
 warn "note: DO NOT use it in a production situation."
 
 usage() {
-	echo "usage: git flow support [list] [-v]"
-	echo "       git flow support start [-F] <version> <base>"
+	echo "usage: git flow $PREFIX [list] [-v]"
+	echo "       git flow $PREFIX start [-F] <version> <base>"
 }
 
 cmd_default() {

--- a/git-flow-support
+++ b/git-flow-support
@@ -41,6 +41,7 @@ init() {
   require_gitflow_initialized
   gitflow_load_settings
   VERSION_PREFIX=$(eval "echo `git config --get gitflow.prefix.versiontag`")
+  DELIMITER="$(git config --get gitflow.prefix.delimiter)";
   PREFIX=$(git config --get gitflow.prefix.support)
 }
 
@@ -63,7 +64,7 @@ cmd_list() {
 	local support_branches
 	local current_branch
 	local short_names
-	support_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX")
+	support_branches=$(echo "$(git_local_branches)" | grep "^$PREFIX$DELIMITER")
 	if [ -z "$support_branches" ]; then
 		warn "No support branches exist."
                 warn ""
@@ -74,7 +75,7 @@ cmd_list() {
 		exit 0
 	fi
 	current_branch=$(git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g')
-	short_names=$(echo "$support_branches" | sed "s ^$PREFIX  g")
+	short_names=$(echo "$support_branches" | sed "s ^$PREFIX$DELIMITER  g")
 
 	# determine column width first
 	local width=0
@@ -87,7 +88,7 @@ cmd_list() {
 
 	local branch
 	for branch in $short_names; do
-		local fullname=$PREFIX$branch
+		local fullname=$PREFIX$DELIMITER$branch
 		local base=$(git merge-base "$fullname" "$MASTER_BRANCH")
 		local master_sha=$(git rev-parse "$MASTER_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
@@ -130,7 +131,7 @@ parse_args() {
 	# read arguments into global variables
 	VERSION=$1
 	BASE=$2
-	BRANCH=$PREFIX$VERSION
+	BRANCH=$PREFIX$DELIMITER$VERSION
 }
 
 require_version_arg() {

--- a/gitflow-common
+++ b/gitflow-common
@@ -176,6 +176,7 @@ gitflow_has_develop_configured() {
 }
 
 gitflow_has_prefixes_configured() {
+	git config --get gitflow.prefix.delimiter >/dev/null 2>&1   && \
 	git config --get gitflow.prefix.feature >/dev/null 2>&1     && \
 	git config --get gitflow.prefix.release >/dev/null 2>&1     && \
 	git config --get gitflow.prefix.hotfix >/dev/null 2>&1      && \


### PR DESCRIPTION
**How to test**
- run `git flow init`
- when asked for delimiter enter custom delimiter (only valid characters for git branch names)
- when asked for branch prefixes, enter custom prefix (without delimiter)
- run `git flow help`
- run `git flow <prefix> help`
- run `git flow <prefix> <subaction>`

**Example**
```
$ git flow init
No branches exist yet. Base branches must be created now.
Branch name for production releases: [master] release
Branch name for "next release" development: [develop] integration

How to name your supporting branch prefixes?
Delimiter between prefix and name? [/] 
Feature branches? [feature] change
Release branches? [release] candidate
Hotfix branches? [hotfix] 
Support branches? [support] 
Version tag prefix? [] 
```
```
$ git flow help
usage: git flow <subcommand>

Available subcommands are:
    init	Initialize a new git repo with support for the branching model.
    change	Manage your change branches.
    candidate	Manage your candidate branches.
    hotfix	Manage your hotfix branches.
    support	Manage your support branches.
    version	Shows version information.

Try 'git flow <subcommand> help' for details.
```