### PR TITLE
replaced all instances of master with main

### DIFF
--- a/Changes.mdown
+++ b/Changes.mdown
@@ -87,7 +87,7 @@ Release date: **2010/07/22**
 * No commands fetch from `origin` by default anymore.  
   There were some issues related to disabling this flag on some platforms.
 
-* Init guesses branch names you may want to use for `develop` and `master`.
+* Init guesses branch names you may want to use for `develop` and `main`.
 
 * Added super-easy installation script. (Thanks [Rick][3].)
 

--- a/README.mdown
+++ b/README.mdown
@@ -59,7 +59,7 @@ Fork the repository.  Then, run:
 
     git clone --recursive git@github.com:<username>/gitflow.git
     cd gitflow
-    git branch master origin/master
+    git branch main origin/main
     git flow init -d
     git flow feature start <your feature>
 
@@ -123,14 +123,14 @@ The ``-d`` flag will accept all defaults.
   		git flow hotfix start <release> [<base>]
   		git flow hotfix finish <release>
   
-  For hotfix branches, the `<base>` arg must be a commit on `master`.
+  For hotfix branches, the `<base>` arg must be a commit on `main`.
 
 * To list/start support branches, use:
   
   		git flow support
   		git flow support start <release> <base>
   
-  For support branches, the `<base>` arg must be a commit on `master`.
+  For support branches, the `<base>` arg must be a commit on `main`.
 
 
 Showing your appreciation

--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -2,7 +2,7 @@
 
 # git-flow make-less installer for *nix systems, by Rick Osborne
 # Based on the git-flow core Makefile:
-# http://github.com/nvie/gitflow/blob/master/Makefile
+# http://github.com/nvie/gitflow/blob/main/Makefile
 
 # Licensed under the same restrictions as git-flow:
 # http://github.com/nvie/gitflow/blob/develop/LICENSE

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -88,8 +88,8 @@ cmd_list() {
 	local branch
 	for branch in $short_names; do
 		local fullname=$PREFIX$branch
-		local base=$(git merge-base "$fullname" "$MASTER_BRANCH")
-		local master_sha=$(git rev-parse "$MASTER_BRANCH")
+		local base=$(git merge-base "$fullname" "$MAIN_BRANCH")
+		local main_sha=$(git rev-parse "$MAIN_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
 		if [ "$fullname" = "$current_branch" ]; then
 			printf "* "
@@ -98,7 +98,7 @@ cmd_list() {
 		fi
 		if flag verbose; then
 			printf "%-${width}s" "$branch"
-			if [ "$branch_sha" = "$master_sha" ]; then
+			if [ "$branch_sha" = "$main_sha" ]; then
 				printf "(no commits yet)"
 			else
 				local tagname=$(git name-rev --tags --no-undefined --name-only "$base")
@@ -140,11 +140,11 @@ require_version_arg() {
 	fi
 }
 
-require_base_is_on_master() {
+require_base_is_on_main() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
 			| sed 's/[* ] //g' \
-	  		| grep -q "^$MASTER_BRANCH\$"; then
-		die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+	  		| grep -q "^$MAIN_BRANCH\$"; then
+		die "fatal: Given base '$BASE' is not a valid commit on '$MAIN_BRANCH'."
 	fi
 }
 
@@ -159,9 +159,9 @@ require_no_existing_hotfix_branches() {
 cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
-	BASE=${2:-$MASTER_BRANCH}
+	BASE=${2:-$MAIN_BRANCH}
 	require_version_arg
-	require_base_is_on_master
+	require_base_is_on_main
 	require_no_existing_hotfix_branches
 
 	# sanity checks
@@ -169,10 +169,10 @@ cmd_start() {
 	require_branch_absent "$BRANCH"
 	require_tag_absent "$VERSION_PREFIX$VERSION"
 	if flag fetch; then
-		git_do fetch -q "$ORIGIN" "$MASTER_BRANCH"
+		git_do fetch -q "$ORIGIN" "$MAIN_BRANCH"
 	fi
-	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if has "$ORIGIN/$MAIN_BRANCH" $(git_remote_branches); then
+		require_branches_equal "$MAIN_BRANCH" "$ORIGIN/$MAIN_BRANCH"
 	fi
 
 	# create branch
@@ -260,24 +260,24 @@ cmd_finish() {
 	require_branch "$BRANCH"
 	require_clean_working_tree
 	if flag fetch; then
-		git_do fetch -q "$ORIGIN" "$MASTER_BRANCH" || \
-		  die "Could not fetch $MASTER_BRANCH from $ORIGIN."
+		git_do fetch -q "$ORIGIN" "$MAIN_BRANCH" || \
+		  die "Could not fetch $MAIN_BRANCH from $ORIGIN."
 		git_do fetch -q "$ORIGIN" "$DEVELOP_BRANCH" || \
 		  die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
 	fi
-	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if has "$ORIGIN/$MAIN_BRANCH" $(git_remote_branches); then
+		require_branches_equal "$MAIN_BRANCH" "$ORIGIN/$MAIN_BRANCH"
 	fi
 	if has "$ORIGIN/$DEVELOP_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
-	# try to merge into master
+	# try to merge into main
 	# in case a previous attempt to finish this release branch has failed,
-	# but the merge into master was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
-		git_do checkout "$MASTER_BRANCH" || \
-		  die "Could not check out $MASTER_BRANCH."
+	# but the merge into main was successful, we skip it now
+	if ! git_is_branch_merged_into "$BRANCH" "$MAIN_BRANCH"; then
+		git_do checkout "$MAIN_BRANCH" || \
+		  die "Could not check out $MAIN_BRANCH."
 		git_do merge --no-ff "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
@@ -321,8 +321,8 @@ cmd_finish() {
 	if flag push; then
 		git_do push "$ORIGIN" "$DEVELOP_BRANCH" || \
 			die "Could not push to $DEVELOP_BRANCH from $ORIGIN."
-		git_do push "$ORIGIN" "$MASTER_BRANCH" || \
-			die "Could not push to $MASTER_BRANCH from $ORIGIN."
+		git_do push "$ORIGIN" "$MAIN_BRANCH" || \
+			die "Could not push to $MAIN_BRANCH from $ORIGIN."
 		if noflag notag; then
 			git_do push --tags "$ORIGIN" || \
 				die "Could not push tags to $ORIGIN."
@@ -332,7 +332,7 @@ cmd_finish() {
 	echo
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
-	echo "- Hotfix branch has been merged into '$MASTER_BRANCH'"
+	echo "- Hotfix branch has been merged into '$MAIN_BRANCH'"
 	if noflag notag; then
 		echo "- The hotfix was tagged '$VERSION_PREFIX$VERSION'"
 	fi
@@ -343,7 +343,7 @@ cmd_finish() {
 		echo "- Hotfix branch '$BRANCH' has been deleted"
 	fi
 	if flag push; then
-		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
+		echo "- '$DEVELOP_BRANCH', '$MAIN_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
 	echo
 }

--- a/git-flow-init
+++ b/git-flow-init
@@ -73,16 +73,16 @@ cmd_default() {
         warn "Using default branch names."
     fi
 
-	# add a master branch if no such branch exists yet
-	local master_branch
-	if gitflow_has_master_configured && ! flag force; then
-		master_branch=$(git config --get gitflow.branch.master)
+	# add a main branch if no such branch exists yet
+	local main_branch
+	if gitflow_has_main_configured && ! flag force; then
+		main_branch=$(git config --get gitflow.branch.main)
 	else
 		# Two cases are distinguished:
 		# 1. A fresh git repo (without any branches)
-		#    We will create a new master/develop branch for the user
+		#    We will create a new main/develop branch for the user
 		# 2. Some branches do already exist
-		#    We will disallow creation of new master/develop branches and
+		#    We will disallow creation of new main/develop branches and
 		#    rather allow to use existing branches for git-flow.
 		local default_suggestion
 		local should_check_existence
@@ -90,7 +90,7 @@ cmd_default() {
 		if [ "$branch_count" -eq 0 ]; then
 			echo "No branches exist yet. Base branches must be created now."
 			should_check_existence=NO
-			default_suggestion=$(git config --get gitflow.branch.master || echo master)
+			default_suggestion=$(git config --get gitflow.branch.main || echo main)
 		else
 			echo
 			echo "Which branch should be used for bringing forth production releases?"
@@ -98,8 +98,8 @@ cmd_default() {
 
 			should_check_existence=YES
 			default_suggestion=
-			for guess in $(git config --get gitflow.branch.master) \
-			             'production' 'main' 'master'; do
+			for guess in $(git config --get gitflow.branch.main) \
+			             'production' 'main' 'main'; do
 				if git_local_branch_exists "$guess"; then
 					default_suggestion="$guess"
 					break
@@ -113,22 +113,22 @@ cmd_default() {
 		else
 			printf "\n"
 		fi
-		master_branch=${answer:-$default_suggestion}
+		main_branch=${answer:-$default_suggestion}
 
 		# check existence in case of an already existing repo
 		if [ "$should_check_existence" = "YES" ]; then
 			# if no local branch exists and a remote branch of the same
-			# name exists, checkout that branch and use it for master
-			if ! git_local_branch_exists "$master_branch" && \
-				git_remote_branch_exists "origin/$master_branch"; then
-				git_do branch "$master_branch" "origin/$master_branch" >/dev/null 2>&1
-			elif ! git_local_branch_exists "$master_branch"; then
-				die "Local branch '$master_branch' does not exist."
+			# name exists, checkout that branch and use it for main
+			if ! git_local_branch_exists "$main_branch" && \
+				git_remote_branch_exists "origin/$main_branch"; then
+				git_do branch "$main_branch" "origin/$main_branch" >/dev/null 2>&1
+			elif ! git_local_branch_exists "$main_branch"; then
+				die "Local branch '$main_branch' does not exist."
 			fi
 		fi
 
-		# store the name of the master branch
-		git_do config gitflow.branch.master "$master_branch"
+		# store the name of the main branch
+		git_do config gitflow.branch.main "$main_branch"
 	fi
 
 	# add a develop branch if no such branch exists yet
@@ -136,24 +136,24 @@ cmd_default() {
 	if gitflow_has_develop_configured && ! flag force; then
 		develop_branch=$(git config --get gitflow.branch.develop)
 	else
-		# Again, the same two cases as with the master selection are
+		# Again, the same two cases as with the main selection are
 		# considered (fresh repo or repo that contains branches)
 		local default_suggestion
 		local should_check_existence
-		branch_count=$(git_local_branches | grep -v "^${master_branch}\$" | wc -l)
+		branch_count=$(git_local_branches | grep -v "^${main_branch}\$" | wc -l)
 		if [ "$branch_count" -eq 0 ]; then
 			should_check_existence=NO
 			default_suggestion=$(git config --get gitflow.branch.develop || echo develop)
 		else
 			echo
 			echo "Which branch should be used for integration of the \"next release\"?"
-			git_local_branches | grep -v "^${master_branch}\$" | sed 's/^.*$/   - &/g'
+			git_local_branches | grep -v "^${main_branch}\$" | sed 's/^.*$/   - &/g'
 
 			should_check_existence=YES
 			default_suggestion=
 			for guess in $(git config --get gitflow.branch.develop) \
-			             'develop' 'int' 'integration' 'master'; do
-				if git_local_branch_exists "$guess" && [ "$guess" != "$master_branch" ]; then
+			             'develop' 'int' 'integration' 'main'; do
+				if git_local_branch_exists "$guess" && [ "$guess" != "$main_branch" ]; then
 					default_suggestion="$guess"
 					break
 				fi
@@ -174,7 +174,7 @@ cmd_default() {
 		fi
 		develop_branch=${answer:-$default_suggestion}
 
-		if [ "$master_branch" = "$develop_branch" ]; then
+		if [ "$main_branch" = "$develop_branch" ]; then
 			die "Production and integration branches should differ."
 		fi
 
@@ -194,28 +194,28 @@ cmd_default() {
 	# it to be able to create new branches.
 	local created_gitflow_branch=0
 	if ! git rev-parse --quiet --verify HEAD >/dev/null 2>&1; then
-		git_do symbolic-ref HEAD "refs/heads/$master_branch"
+		git_do symbolic-ref HEAD "refs/heads/$main_branch"
 		git_do commit --allow-empty --quiet -m "Initial commit"
 		created_gitflow_branch=1
 	fi
 
-	# Creation of master
+	# Creation of main
 	# ------------------
-	# At this point, there always is a master branch: either it existed already
+	# At this point, there always is a main branch: either it existed already
 	# (and was picked interactively as the production branch) or it has just
 	# been created in a fresh repo
 
 	# Creation of develop
 	# -------------------
 	# The develop branch possibly does not exist yet.  This is the case when,
-	# in a git init'ed repo with one or more commits, master was picked as the
+	# in a git init'ed repo with one or more commits, main was picked as the
 	# default production branch and develop was "created".  We should create
-	# the develop branch now in that case (we base it on master, of course)
+	# the develop branch now in that case (we base it on main, of course)
 	if ! git_local_branch_exists "$develop_branch"; then
 		if git_remote_branch_exists "origin/$develop_branch"; then
 			git_do branch "$develop_branch" "origin/$develop_branch" >/dev/null 2>&1
 		else
-			git_do branch --no-track "$develop_branch" "$master_branch"
+			git_do branch --no-track "$develop_branch" "$main_branch"
 		fi
 		created_gitflow_branch=1
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -210,24 +210,24 @@ cmd_finish() {
 	require_branch "$BRANCH"
 	require_clean_working_tree
 	if flag fetch; then
-		git_do fetch -q "$ORIGIN" "$MASTER_BRANCH" || \
-		  die "Could not fetch $MASTER_BRANCH from $ORIGIN."
+		git_do fetch -q "$ORIGIN" "$MAIN_BRANCH" || \
+		  die "Could not fetch $MAIN_BRANCH from $ORIGIN."
 		git_do fetch -q "$ORIGIN" "$DEVELOP_BRANCH" || \
 		  die "Could not fetch $DEVELOP_BRANCH from $ORIGIN."
 	fi
-	if has "$ORIGIN/$MASTER_BRANCH" $(git_remote_branches); then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if has "$ORIGIN/$MAIN_BRANCH" $(git_remote_branches); then
+		require_branches_equal "$MAIN_BRANCH" "$ORIGIN/$MAIN_BRANCH"
 	fi
 	if has "$ORIGIN/$DEVELOP_BRANCH" $(git_remote_branches); then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
-	# try to merge into master
+	# try to merge into main
 	# in case a previous attempt to finish this release branch has failed,
-	# but the merge into master was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
-		git_do checkout "$MASTER_BRANCH" || \
-		  die "Could not check out $MASTER_BRANCH."
+	# but the merge into main was successful, we skip it now
+	if ! git_is_branch_merged_into "$BRANCH" "$MAIN_BRANCH"; then
+		git_do checkout "$MAIN_BRANCH" || \
+		  die "Could not check out $MAIN_BRANCH."
 		if noflag squash; then
 			git_do merge --no-ff "$BRANCH" || \
 				die "There were merge conflicts."
@@ -279,7 +279,7 @@ cmd_finish() {
 	# delete branch
 	if noflag keep; then
 		if [ "$BRANCH" = "$(git_current_branch)" ]; then
-			git_do checkout "$MASTER_BRANCH"
+			git_do checkout "$MAIN_BRANCH"
 		fi
 		git_do branch -d "$BRANCH"
 	fi
@@ -287,8 +287,8 @@ cmd_finish() {
 	if flag push; then
 		git_do push "$ORIGIN" "$DEVELOP_BRANCH" || \
 			die "Could not push to $DEVELOP_BRANCH from $ORIGIN."
-		git_do push "$ORIGIN" "$MASTER_BRANCH" || \
-			die "Could not push to $MASTER_BRANCH from $ORIGIN."
+		git_do push "$ORIGIN" "$MAIN_BRANCH" || \
+			die "Could not push to $MAIN_BRANCH from $ORIGIN."
 		if noflag notag; then
 			git_do push --tags "$ORIGIN" || \
 			  die "Could not push tags to $ORIGIN."
@@ -300,7 +300,7 @@ cmd_finish() {
 	echo
 	echo "Summary of actions:"
 	echo "- Latest objects have been fetched from '$ORIGIN'"
-	echo "- Release branch has been merged into '$MASTER_BRANCH'"
+	echo "- Release branch has been merged into '$MAIN_BRANCH'"
 	if noflag notag; then
 		echo "- The release was tagged '$tagname'"
 	fi
@@ -311,7 +311,7 @@ cmd_finish() {
 		echo "- Release branch '$BRANCH' has been deleted"
 	fi
 	if flag push; then
-		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
+		echo "- '$DEVELOP_BRANCH', '$MAIN_BRANCH' and tags have been pushed to '$ORIGIN'"
 		echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
 	fi
 	echo

--- a/git-flow-support
+++ b/git-flow-support
@@ -88,8 +88,8 @@ cmd_list() {
 	local branch
 	for branch in $short_names; do
 		local fullname=$PREFIX$branch
-		local base=$(git merge-base "$fullname" "$MASTER_BRANCH")
-		local master_sha=$(git rev-parse "$MASTER_BRANCH")
+		local base=$(git merge-base "$fullname" "$MAIN_BRANCH")
+		local main_sha=$(git rev-parse "$MAIN_BRANCH")
 		local branch_sha=$(git rev-parse "$fullname")
 		if [ "$fullname" = "$current_branch" ]; then
 			printf "* "
@@ -98,7 +98,7 @@ cmd_list() {
 		fi
 		if flag verbose; then
 			printf "%-${width}s" "$branch"
-			if [ "$branch_sha" = "$master_sha" ]; then
+			if [ "$branch_sha" = "$main_sha" ]; then
 				printf "(no commits yet)"
 			else
 				local tagname=$(git name-rev --tags --no-undefined --name-only "$base")
@@ -149,11 +149,11 @@ require_base_arg() {
 	fi
 }
 
-require_base_is_on_master() {
+require_base_is_on_main() {
 	if ! git branch --no-color --contains "$BASE" 2>/dev/null \
 			| sed 's/[* ] //g' \
-	  		| grep -q "^$MASTER_BRANCH\$"; then
-		die "fatal: Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+	  		| grep -q "^$MAIN_BRANCH\$"; then
+		die "fatal: Given base '$BASE' is not a valid commit on '$MAIN_BRANCH'."
 	fi
 }
 
@@ -162,7 +162,7 @@ cmd_start() {
 	parse_args "$@"
 	require_version_arg
 	require_base_arg
-	require_base_is_on_master
+	require_base_is_on_main
 
 	# sanity checks
 	require_clean_working_tree

--- a/gitflow-common
+++ b/gitflow-common
@@ -165,9 +165,9 @@ git_is_branch_merged_into() {
 #
 
 # check if this repo has been inited for gitflow
-gitflow_has_master_configured() {
-	local master=$(git config --get gitflow.branch.master)
-	[ "$master" != "" ] && git_local_branch_exists "$master"
+gitflow_has_main_configured() {
+	local main=$(git config --get gitflow.branch.main)
+	[ "$main" != "" ] && git_local_branch_exists "$main"
 }
 
 gitflow_has_develop_configured() {
@@ -184,9 +184,9 @@ gitflow_has_prefixes_configured() {
 }
 
 gitflow_is_initialized() {
-	gitflow_has_master_configured                    && \
+	gitflow_has_main_configured                    && \
 	gitflow_has_develop_configured                   && \
-	[ "$(git config --get gitflow.branch.master)" !=    \
+	[ "$(git config --get gitflow.branch.main)" !=    \
 	  "$(git config --get gitflow.branch.develop)" ] && \
 	gitflow_has_prefixes_configured
 }
@@ -194,7 +194,7 @@ gitflow_is_initialized() {
 # loading settings that can be overridden using git config
 gitflow_load_settings() {
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
+	export MAIN_BRANCH=$(git config --get gitflow.branch.main)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)
 	export ORIGIN=$(git config --get gitflow.origin || echo origin)
 }


### PR DESCRIPTION
Trying to facilitate some thoughtful change surrounding the words we use.  This fork blindly replaced all uses of the word 'master' (based on its natural relation to the word 'slave') allowing us to easily adopt the alternative term 'main'.  

Submitting back to you here for your consideration as an 'improvement', or the beginning of a new permanent fork or branch could prompt/encourage the user to migrate to the use of 'main'. 