### PR TITLE
Deprecated methods migration and submodule protocol changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git

--- a/git-flow
+++ b/git-flow
@@ -38,7 +38,7 @@
 #
 
 # set this to workaround expr problems in shFlags on freebsd
-if uname -s | egrep -iq 'bsd'; then export EXPR_COMPAT=1; fi
+if uname -s | grep -E 'bsd'; then export EXPR_COMPAT=1; fi
 
 # enable debug mode
 if [ "$DEBUG" = "yes" ]; then


### PR DESCRIPTION
The git protocol is deprecated.
https://github.blog/2021-09-01-improving-git-protocol-security-github

egrep has been replaced by grep.
https://savannah.gnu.org/forum/forum.php?forum_id=10227