### PR TITLE
Use https:// url instead of git:// for shFlags submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git


### PR DESCRIPTION
I was unable to recursively clone the repository because of the `git://` submodule url. I'm not sure whether this is due to me having a very modern Git installation on Fedora 38, or due to GitHub nowadays refusing the `git://` protocol. Either way, changing it to `https://` fixed it.